### PR TITLE
ci(ci): remove subject case restriction from commit policy

### DIFF
--- a/.github/scripts/validate-commit-message.sh
+++ b/.github/scripts/validate-commit-message.sh
@@ -31,14 +31,6 @@ else
   fi
 
   subject="$(printf '%s' "$first_line" | sed -E "s/^(${allowed_types})\\((${allowed_scopes})\\): //")"
-  first_subject_char="$(printf '%s' "$subject" | cut -c1)"
-
-  case "$first_subject_char" in
-    [A-Z])
-      echo "Commit subject must not start with a capital letter." >&2
-      exit 1
-      ;;
-  esac
 
   case "$subject" in
     *.)


### PR DESCRIPTION
## Summary
Removes the check that rejected commit subjects starting with a capital letter. Type, scope, and line-length enforcement remain intact.

## Test plan
- [ ] CI commit-policy passes on this PR itself
- [ ] Existing valid lowercase subjects still pass
- [ ] Subjects starting with a capital letter now pass

Closes #44