### PR TITLE
fix(runtime): surface llama-swap configured models without claiming residency

### DIFF
--- a/crates/anemoi-core/src/lib.rs
+++ b/crates/anemoi-core/src/lib.rs
@@ -146,6 +146,13 @@ pub struct RuntimeSnapshot {
     pub runtime_id: RuntimeId,
     pub available: bool,
     pub residents: Vec<ModelResident>,
+    /// Models the runtime reports as configured/registered (e.g. listed by
+    /// `/v1/models`). Configuration is not evidence of residency — see
+    /// `docs/live_validation/residency-truth-contract.md`. Use this for
+    /// candidate enumeration and rejected-options reasoning, not for hot
+    /// reuse bonuses.
+    #[serde(default)]
+    pub configured_models: Vec<ModelId>,
     pub memory: RuntimeMemorySnapshot,
     pub active_requests: Vec<ActiveExecution>,
 }

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -55,6 +55,7 @@ impl ReconciledSnapshot {
             runtime_id,
             available: false,
             residents: Vec::new(),
+            configured_models: Vec::new(),
             memory: anemoi_core::RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         };
@@ -1129,6 +1130,7 @@ mod tests {
             runtime_id: RuntimeId("test".to_string()),
             available: true,
             residents: vec![],
+            configured_models: Vec::new(),
             memory: anemoi_core::RuntimeMemorySnapshot::default(),
             active_requests: vec![],
         };

--- a/crates/anemoi-policy/src/lib.rs
+++ b/crates/anemoi-policy/src/lib.rs
@@ -649,6 +649,7 @@ continuity:
                 kv_cache_mb: None,
                 loaded_since: None,
             }],
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         };
@@ -703,6 +704,7 @@ continuity:
             runtime_id: RuntimeId("llama_swap".to_string()),
             available: true,
             residents: Vec::new(),
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         };
@@ -731,6 +733,7 @@ continuity:
             runtime_id: RuntimeId("llama_swap".to_string()),
             available: true,
             residents: Vec::new(),
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         };
@@ -771,6 +774,7 @@ continuity:
             runtime_id: RuntimeId("mock".to_string()),
             available: true,
             residents: Vec::new(),
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         };
@@ -863,6 +867,7 @@ continuity:
                 kv_cache_mb: None,
                 loaded_since: None,
             }],
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         }

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -64,6 +64,7 @@ impl MockRuntimeAdapter {
                 runtime_id: id,
                 available: true,
                 residents,
+                configured_models: Vec::new(),
                 memory: RuntimeMemorySnapshot::default(),
                 active_requests: Vec::new(),
             })),
@@ -208,6 +209,7 @@ impl RuntimeAdapter for OllamaAdapter {
                 runtime_id: self.id.clone(),
                 available: false,
                 residents: Vec::new(),
+                configured_models: Vec::new(),
                 memory: RuntimeMemorySnapshot::default(),
                 active_requests: Vec::new(),
             });
@@ -231,6 +233,7 @@ impl RuntimeAdapter for OllamaAdapter {
             runtime_id: self.id.clone(),
             available: true,
             residents,
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         })
@@ -354,19 +357,22 @@ impl RuntimeAdapter for LlamaSwapAdapter {
                 runtime_id: self.id.clone(),
                 available: false,
                 residents: Vec::new(),
+                configured_models: Vec::new(),
                 memory: RuntimeMemorySnapshot::default(),
                 active_requests: Vec::new(),
             });
         }
 
-        let _models = self.inspect_models().await?;
+        let configured_models = self.inspect_models().await?;
 
         Ok(RuntimeSnapshot {
             runtime_id: self.id.clone(),
             available: true,
-            // Needs validation: llama-swap /v1/models proves configured models,
-            // not currently resident/running models.
+            // /v1/models proves configuration, not residency — see
+            // docs/live_validation/residency-truth-contract.md. residents stays
+            // empty until we have evidence the model is loaded.
             residents: Vec::new(),
+            configured_models,
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         })
@@ -424,6 +430,7 @@ impl RuntimeAdapter for HttpInspectAdapter {
             runtime_id: self.id.clone(),
             available,
             residents: Vec::new(),
+            configured_models: Vec::new(),
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
         })
@@ -863,6 +870,59 @@ mod tests {
             snapshot.residents.len(),
             0,
             "configured models without runtime evidence must not be hot"
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_swap_inspect_populates_residents_from_models_endpoint() {
+        // Name preserved from issue #46. Per the residency truth contract,
+        // /v1/models proves configuration, not residency — so configured
+        // models surface in `configured_models`, not `residents`.
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(
+                200,
+                r#"{"data":[{"id":"models/qwen9b.gguf"},{"id":"granite8b"}]}"#,
+            ),
+        ])
+        .await;
+        let adapter = LlamaSwapAdapter::new(RuntimeId("llama_swap".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert!(snapshot.available);
+        assert_eq!(
+            snapshot.configured_models,
+            vec![
+                ModelId("qwen9b".to_string()),
+                ModelId("granite8b".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_swap_inspect_marks_residents_as_configured_not_hot() {
+        // Name preserved from issue #46. Configured models from /v1/models must
+        // not be reported as residents at all — residency requires evidence
+        // beyond configuration (see residency-truth-contract.md).
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[{"id":"models/qwen9b.gguf"}]}"#),
+        ])
+        .await;
+        let adapter = LlamaSwapAdapter::new(RuntimeId("llama_swap".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert_eq!(
+            snapshot.configured_models,
+            vec![ModelId("qwen9b".to_string())]
+        );
+        assert!(
+            snapshot.residents.is_empty(),
+            "configured models must not appear as residents"
         );
     }
 

--- a/docs/live_validation/residency-truth-contract.md
+++ b/docs/live_validation/residency-truth-contract.md
@@ -58,6 +58,11 @@ This ensures Anemoi is conservative: unknown means cold until proven otherwise.
 - `/v1/models` lists configured models but does **not** prove residency.
 - `inspect()` returns empty residents. Configured models remain `Cold`.
 - `inspect_models()` returns configured model IDs for reference, not residency.
+- The configured model list is surfaced on the snapshot as
+  `configured_models: Vec<ModelId>`. This is configuration evidence, not
+  residency evidence — policy may use it for candidate enumeration and
+  rejected-options reasoning, but it must not contribute a hot-reuse
+  bonus and it does not change the `Cold` residency state of any model.
 
 ### HttpInspectAdapter (llama.cpp / llama_server)
 - Health check confirms process is reachable.


### PR DESCRIPTION
## Summary

- `LlamaSwapAdapter::inspect()` now populates a new `configured_models: Vec<ModelId>` field on `RuntimeSnapshot` from `/v1/models`. Previously `inspect()` discarded the result, so anemoi had zero visibility into what models llama-swap was hosting.
- `residents` stays empty — `/v1/models` proves configuration, not residency, exactly as `docs/live_validation/residency-truth-contract.md` requires. The "false-hot" failure mode the contract guards against is preserved.
- Policy may use `configured_models` for candidate enumeration and rejected-options reasoning without granting any hot-reuse bonus or changing the `Cold` residency state of any model.
- Updates `residency-truth-contract.md` to document the new field's evidence semantics.

## Changes from the original Codex-reviewed version

The first version of this PR added a `ResidencyState::Configured` variant and populated `residents` with it. Codex (P2) flagged this as a contradiction of the checked-in residency truth contract and an unauthorized expansion of `AGENTS.md` §7 — both correct. This revision drops the `Configured` state entirely and surfaces configured models on a separate field, which is what the contract's "configuration vs. residency" distinction already implies.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Required tests landed (visible by name in `cargo test --workspace` output, names preserved from issue #46):
- `llama_swap_inspect_populates_residents_from_models_endpoint` — asserts `configured_models` is populated (the field name is now distinct from `residents` but the test name still reflects the issue's framing of "make the models from `/v1/models` visible")
- `llama_swap_inspect_marks_residents_as_configured_not_hot` — asserts the model is in `configured_models` and `residents` stays empty, i.e. configuration evidence is recorded but residency is not claimed

## Notes

- `RuntimeSnapshot::configured_models` is `#[serde(default)]` for backward-compatible deserialization of older snapshots from telemetry.
- Construction sites across `anemoi-core`, `anemoi-runtime`, `anemoi-policy`, and `anemoi-daemon` updated to include the new field (`Vec::new()` everywhere except the llama-swap inspect path).
- The policy crate's candidate enumeration loop is untouched in this PR — surfacing rejected_options off `configured_models` is a behavior-shaping follow-up, not a blocker for the adapter-layer bug fix.

Closes #46