### PR TITLE
fix(runtime): llama-swap load_model triggers a real load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "chrono",
  "reqwest",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "uuid",

--- a/crates/anemoi-runtime/Cargo.toml
+++ b/crates/anemoi-runtime/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -373,6 +373,22 @@ impl RuntimeAdapter for LlamaSwapAdapter {
     }
 
     async fn load_model(&self, model: &ModelId) -> Result<LoadHandle, RuntimeError> {
+        let url = self
+            .base_url
+            .join("/v1/chat/completions")
+            .map_err(|error| RuntimeError::Url(error.to_string()))?;
+        let body = serde_json::json!({
+            "model": model.to_string(),
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+        });
+        self.client
+            .post(url)
+            .headers(self.headers()?)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
         Ok(LoadHandle {
             id: Uuid::new_v4(),
             model_id: model.clone(),
@@ -893,6 +909,50 @@ mod tests {
 
         assert_eq!(snapshot.residents.len(), 1);
         assert_eq!(snapshot.residents[0].state, ResidencyState::HotGpu);
+    }
+
+    #[tokio::test]
+    async fn llama_swap_load_model_posts_to_chat_completions() {
+        let server = spawn_fixture(vec![http_response(
+            200,
+            r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#,
+        )])
+        .await;
+        let adapter = LlamaSwapAdapter::new(RuntimeId("llama_swap".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let handle = adapter
+            .load_model(&ModelId("qwen9b".to_string()))
+            .await
+            .expect("load handle");
+
+        assert_eq!(handle.model_id, ModelId("qwen9b".to_string()));
+
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert!(
+            request.starts_with("POST /v1/chat/completions"),
+            "load_model must POST to /v1/chat/completions, got: {request:?}"
+        );
+        assert!(
+            request.contains("\"model\":\"qwen9b\""),
+            "request must carry the requested model id, got: {request:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_swap_load_model_surfaces_upstream_5xx_as_error() {
+        let server = spawn_fixture(vec![http_response(500, "{}")]).await;
+        let adapter = LlamaSwapAdapter::new(RuntimeId("llama_swap".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let error = adapter
+            .load_model(&ModelId("qwen9b".to_string()))
+            .await
+            .expect_err("upstream 5xx must surface as error");
+
+        assert!(matches!(error, RuntimeError::Http(_)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `LlamaSwapAdapter::load_model()` now POSTs to `/v1/chat/completions` with `{"model": id, "messages": [...], "max_tokens": 1}` — the documented OpenAI-compatible load trigger. Previously it returned `Ok(LoadHandle::new())` without contacting llama-swap, so `ANEMOI_ENABLE_LIVE_EXECUTE` was gating a no-op and `handoff.load_requested=true` was a lie.
- Non-2xx responses surface as `RuntimeError::Http` via `error_for_status()`, so an upstream failure now flips `handoff.load_requested` to `false` instead of silently succeeding.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Required tests landed (visible by name in `cargo test --workspace` output):
- `llama_swap_load_model_posts_to_chat_completions`
- `llama_swap_load_model_surfaces_upstream_5xx_as_error`

## Notes

- Adds `serde_json` dep to `anemoi-runtime` for building the request body.
- `/v1/chat/completions` is the most portable trigger across llama-swap versions; a dedicated `POST /upstream/<model>/...` control path was not used because v214 surface confirmation would require live access and the OpenAI path achieves the same effect.

Closes #47