### PR TITLE
fix(daemon): /decide reads reconciler cache instead of re-inspecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "anemoi-runtime",
  "anemoi-telemetry",
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "serde",

--- a/crates/anemoi-daemon/Cargo.toml
+++ b/crates/anemoi-daemon/Cargo.toml
@@ -21,4 +21,5 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 tower.workspace = true

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -433,12 +433,10 @@ impl AppState {
     }
 
     pub async fn decide(&self, request: &InferenceRequest) -> anyhow::Result<Decision> {
-        let has_cache = self.reconciler.has_cache().await;
-        let snapshots = if has_cache {
-            self.reconciler.get_snapshots().await
-        } else {
-            self.snapshots().await
-        };
+        if !self.reconciler.has_cache().await {
+            self.run_reconciliation_tick().await;
+        }
+        let snapshots = self.reconciler.get_snapshots().await;
         let decision = self.scheduler.decide(request, &snapshots)?;
 
         if decision.action == DecisionAction::StageBackground {
@@ -1639,6 +1637,71 @@ mod tests {
             still_pending.len(),
             1,
             "non-mock staging intent should stay pending without ANEMOI_ENABLE_LIVE_EXECUTE"
+        );
+    }
+
+    #[tokio::test]
+    async fn decide_burst_reads_reconciler_cache_not_runtime_inspect() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingAdapter {
+            inner: DynRuntimeAdapter,
+            inspects: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl anemoi_runtime::RuntimeAdapter for CountingAdapter {
+            fn id(&self) -> RuntimeId {
+                self.inner.id()
+            }
+            async fn inspect(&self) -> Result<RuntimeSnapshot, anemoi_runtime::RuntimeError> {
+                self.inspects.fetch_add(1, Ordering::SeqCst);
+                self.inner.inspect().await
+            }
+            async fn load_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<anemoi_runtime::LoadHandle, anemoi_runtime::RuntimeError> {
+                self.inner.load_model(model).await
+            }
+            async fn unload_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<(), anemoi_runtime::RuntimeError> {
+                self.inner.unload_model(model).await
+            }
+            async fn execute(
+                &self,
+                request: anemoi_core::ExecutionRequest,
+            ) -> Result<anemoi_runtime::ExecutionHandle, anemoi_runtime::RuntimeError> {
+                self.inner.execute(request).await
+            }
+        }
+
+        let mut state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+        let inspects = Arc::new(AtomicUsize::new(0));
+        let original = state
+            .runtimes
+            .get("mock")
+            .expect("mock runtime present")
+            .clone();
+        state.runtimes.insert(
+            "mock".to_string(),
+            Arc::new(CountingAdapter {
+                inner: original,
+                inspects: inspects.clone(),
+            }),
+        );
+
+        for _ in 0..8 {
+            state.decide(&sample_request()).await.expect("decision");
+        }
+
+        let total = inspects.load(Ordering::SeqCst);
+        assert_eq!(
+            total, 1,
+            "decide burst must reuse the reconciler cache; got {total} inspects"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `AppState::decide()` no longer falls through to `self.snapshots()` (which inspects every adapter) when the reconciler cache is cold. It now always reads `Reconciler::get_snapshots()`, with a one-shot warm-up tick on first call if the cache is empty.
- Subsequent `/decide` calls within the TTL reuse the cached snapshot — the burst-of-inspects-per-request hammering observed against live llama-swap is gone.
- The existing background reconciliation loop in `serve()` (DEFAULT_RECONCILIATION_TTL_MS / 2) remains the source of fresh data; this change just stops `/decide` from racing it.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Required test landed (visible by name in `cargo test --workspace` output):
- `decide_burst_reads_reconciler_cache_not_runtime_inspect`

The test wraps the configured mock adapter in a `CountingAdapter` and asserts that 8 back-to-back `decide()` calls produce exactly 1 underlying `inspect()` (the warm-up).

## Notes

- Adds `async-trait` to `anemoi-daemon` dev-dependencies for the test's adapter wrapper.
- TTL-respecting refresh on stale cache reads was considered but kept out of scope — the background loop handles that path; this PR is the surgical fix for the burst-amplification bug.

Closes #48