### PR TITLE
feat(core): add supports_streaming to ModelProfileConfig (Closes #8)

### DIFF
--- a/config/anemoi.example.yaml
+++ b/config/anemoi.example.yaml
@@ -30,6 +30,7 @@ models:
     vram_required_mb: 9000
     ram_required_mb: 12000
     cold_load_estimate_ms: 18000
+    supports_streaming: true
     supported_runtimes:
       - mock
 
@@ -40,6 +41,7 @@ models:
     vram_required_mb: 8000
     ram_required_mb: 10000
     cold_load_estimate_ms: 15000
+    supports_streaming: true
     supported_runtimes:
       - mock
 
@@ -50,6 +52,7 @@ models:
     vram_required_mb: 30000
     ram_required_mb: 45000
     cold_load_estimate_ms: 45000
+    supports_streaming: true
     supported_runtimes:
       - mock
 

--- a/config/anemoi.prometheus.yaml
+++ b/config/anemoi.prometheus.yaml
@@ -57,6 +57,7 @@ models:
     vram_required_mb: 7000
     ram_required_mb: 0
     cold_load_estimate_ms: 8000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 
@@ -67,6 +68,7 @@ models:
     vram_required_mb: 6000
     ram_required_mb: 0
     cold_load_estimate_ms: 6000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 
@@ -77,6 +79,7 @@ models:
     vram_required_mb: 12000
     ram_required_mb: 20000
     cold_load_estimate_ms: 30000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 
@@ -87,6 +90,7 @@ models:
     vram_required_mb: 14000
     ram_required_mb: 16000
     cold_load_estimate_ms: 25000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 
@@ -97,6 +101,7 @@ models:
     vram_required_mb: 8000
     ram_required_mb: 40000
     cold_load_estimate_ms: 60000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 
@@ -107,6 +112,7 @@ models:
     vram_required_mb: 8000
     ram_required_mb: 80000
     cold_load_estimate_ms: 90000
+    supports_streaming: true
     supported_runtimes:
       - llama_swap
 

--- a/crates/anemoi-core/src/lib.rs
+++ b/crates/anemoi-core/src/lib.rs
@@ -130,6 +130,10 @@ pub struct ModelProfile {
     pub ram_required_mb: Option<u64>,
     pub cold_load_estimate_ms: Option<u64>,
     pub supported_runtimes: Vec<RuntimeId>,
+    /// Whether the model supports SSE streaming responses.
+    /// `None` means unknown (treat as permissive); `Some(false)` means
+    /// explicitly non-streaming; `Some(true)` means streaming is supported.
+    pub supports_streaming: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -481,6 +485,11 @@ pub struct ModelProfileConfig {
     pub ram_required_mb: Option<u64>,
     pub cold_load_estimate_ms: Option<u64>,
     pub supported_runtimes: Vec<RuntimeId>,
+    /// Whether the model supports SSE streaming responses.
+    /// `None` means unknown (treat as permissive); `Some(false)` means
+    /// explicitly non-streaming; `Some(true)` means streaming is supported.
+    #[serde(default)]
+    pub supports_streaming: Option<bool>,
 }
 
 impl ModelProfileConfig {
@@ -494,6 +503,7 @@ impl ModelProfileConfig {
             ram_required_mb: self.ram_required_mb,
             cold_load_estimate_ms: self.cold_load_estimate_ms,
             supported_runtimes: self.supported_runtimes,
+            supports_streaming: self.supports_streaming,
         }
     }
 }
@@ -963,6 +973,68 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn model_profile_config_deserializes_supports_streaming_true() {
+        let config: ModelProfileConfig = serde_yaml::from_str(
+            r#"
+family: qwen
+parameter_class: 9b
+supported_runtimes: [llama_swap]
+supports_streaming: true
+"#,
+        )
+        .expect("profile with supports_streaming: true");
+
+        assert_eq!(config.supports_streaming, Some(true));
+    }
+
+    #[test]
+    fn model_profile_config_deserializes_supports_streaming_false() {
+        let config: ModelProfileConfig = serde_yaml::from_str(
+            r#"
+family: qwen
+parameter_class: 9b
+supported_runtimes: [llama_swap]
+supports_streaming: false
+"#,
+        )
+        .expect("profile with supports_streaming: false");
+
+        assert_eq!(config.supports_streaming, Some(false));
+    }
+
+    #[test]
+    fn model_profile_config_supports_streaming_absent_is_none() {
+        let config: ModelProfileConfig = serde_yaml::from_str(
+            r#"
+family: qwen
+parameter_class: 9b
+supported_runtimes: [llama_swap]
+"#,
+        )
+        .expect("profile without supports_streaming");
+
+        assert_eq!(config.supports_streaming, None);
+    }
+
+    #[test]
+    fn into_profile_carries_supports_streaming() {
+        let config = ModelProfileConfig {
+            family: "qwen".to_string(),
+            parameter_class: "9b".to_string(),
+            context_window: None,
+            vram_required_mb: None,
+            ram_required_mb: None,
+            cold_load_estimate_ms: None,
+            supported_runtimes: vec![RuntimeId("llama_swap".to_string())],
+            supports_streaming: Some(true),
+        };
+
+        let profile = config.into_profile(ModelId("qwen9b".to_string()));
+
+        assert_eq!(profile.supports_streaming, Some(true));
     }
 
     #[test]

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -973,6 +973,7 @@ mod tests {
                 ram_required_mb: None,
                 cold_load_estimate_ms: None,
                 supported_runtimes: vec![RuntimeId("live_target".to_string())],
+                supports_streaming: None,
             },
         );
 

--- a/crates/anemoi-policy/src/lib.rs
+++ b/crates/anemoi-policy/src/lib.rs
@@ -367,6 +367,17 @@ fn score_candidate(
         );
     }
 
+    if let Some(supports_streaming) = model.supports_streaming {
+        let detail = if supports_streaming {
+            format!("{} supports streaming responses", model.id)
+        } else {
+            format!("{} does not support streaming responses", model.id)
+        };
+        // Informational only: streaming capability is surfaced for the
+        // forwarding gateway but does not influence the score.
+        push(&mut score, &mut reasons, "streaming_capability", 0, detail);
+    }
+
     ScoredCandidate {
         action: candidate.action.clone(),
         candidate: candidate.clone(),


### PR DESCRIPTION
## Summary
- Add optional `supports_streaming: Option<bool>` to `ModelProfileConfig` and `ModelProfile`, wired through `into_profile`.
- `None` = unknown (permissive), `Some(false)` = explicitly non-streaming, `Some(true)` = streaming supported. Foundation for the prompt 28 forwarding gateway to warn/reject `stream: true` against non-streaming models.
- Candidate explanation surfaces streaming capability as an informational reason (impact 0) when known.
- Annotate OpenAI-compatible models in `config/anemoi.example.yaml` and `config/anemoi.prometheus.yaml` with `supports_streaming: true`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] New tests: `model_profile_config_deserializes_supports_streaming_true`, `..._false`, `model_profile_config_supports_streaming_absent_is_none`, `into_profile_carries_supports_streaming`
- [x] Existing config fixtures omitting the field still parse

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)