### PR TITLE
feat(runtime): implement LlamaCppAdapter as inspect-only adapter (Closes #4)

### DIFF
--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -4,7 +4,7 @@ use anemoi_core::{
 };
 use anemoi_policy::Scheduler;
 use anemoi_runtime::{
-    DynRuntimeAdapter, HttpInspectAdapter, LlamaSwapAdapter, MockRuntimeAdapter, OllamaAdapter,
+    DynRuntimeAdapter, LlamaCppAdapter, LlamaSwapAdapter, MockRuntimeAdapter, OllamaAdapter,
 };
 use anemoi_telemetry::{DynDecisionLog, InMemoryDecisionLog};
 use axum::extract::{Path, State};
@@ -349,13 +349,21 @@ impl AppState {
                     };
                     Arc::new(adapter)
                 }
-                "llama_cpp" | "llama_server" => Arc::new(HttpInspectAdapter::new(
-                    runtime_id.clone(),
-                    runtime
-                        .base_url
-                        .as_deref()
-                        .unwrap_or("http://localhost:8080"),
-                )?),
+                "llama_cpp" | "llama_server" => {
+                    let adapter = LlamaCppAdapter::new(
+                        runtime_id.clone(),
+                        runtime
+                            .base_url
+                            .as_deref()
+                            .unwrap_or("http://localhost:8080"),
+                    )?;
+                    let adapter = if let Some(token) = &runtime.auth_token {
+                        adapter.with_bearer_token(token)
+                    } else {
+                        adapter
+                    };
+                    Arc::new(adapter)
+                }
                 _ => Arc::new(MockRuntimeAdapter::new(runtime_id.clone(), Vec::new())),
             };
             runtimes.insert(runtime_id.to_string(), adapter);

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -258,7 +258,148 @@ impl RuntimeAdapter for OllamaAdapter {
     }
 }
 
-pub type LlamaCppAdapter = HttpInspectAdapter;
+/// Inspect-only adapter for a llama.cpp / `llama-server` instance.
+///
+/// llama.cpp exposes an OpenAI-compatible `/v1/models` endpoint and a
+/// `/health` endpoint. Per the residency truth contract
+/// (`docs/live_validation/residency-truth-contract.md`), `/v1/models` proves
+/// configuration, not residency — so `inspect()` surfaces those ids in
+/// `configured_models` and leaves `residents` empty. This adapter never
+/// loads, unloads, or executes.
+#[derive(Debug, Clone)]
+pub struct LlamaCppAdapter {
+    id: RuntimeId,
+    base_url: Url,
+    client: reqwest::Client,
+    auth_token: Option<String>,
+}
+
+impl LlamaCppAdapter {
+    pub fn new(id: RuntimeId, base_url: &str) -> Result<Self, RuntimeError> {
+        Self::new_with_timeout(id, base_url, Duration::from_secs(5))
+    }
+
+    pub fn new_with_timeout(
+        id: RuntimeId,
+        base_url: &str,
+        timeout: Duration,
+    ) -> Result<Self, RuntimeError> {
+        Ok(Self {
+            id,
+            base_url: Url::parse(base_url).map_err(|error| RuntimeError::Url(error.to_string()))?,
+            client: reqwest::Client::builder().timeout(timeout).build()?,
+            auth_token: None,
+        })
+    }
+
+    /// Configure a bearer token. The token must originate from the environment
+    /// (expanded at config load); it is never committed.
+    pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
+        self.auth_token = Some(token.into());
+        self
+    }
+
+    /// Returns the configured model ids reported by `/v1/models`. This is
+    /// configuration evidence, not residency evidence.
+    pub async fn inspect_models(&self) -> Result<Vec<ModelId>, RuntimeError> {
+        let url = self
+            .base_url
+            .join("/v1/models")
+            .map_err(|error| RuntimeError::Url(error.to_string()))?;
+        let response: LlamaCppModelsResponse = self
+            .client
+            .get(url)
+            .headers(self.headers()?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(response
+            .data
+            .into_iter()
+            .map(|model| normalize_model_id(&model.id))
+            .collect())
+    }
+
+    fn headers(&self) -> Result<HeaderMap, RuntimeError> {
+        let mut headers = HeaderMap::new();
+        if let Some(token) = &self.auth_token {
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|error| RuntimeError::Url(error.to_string()))?;
+            headers.insert(AUTHORIZATION, value);
+        }
+        Ok(headers)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LlamaCppModelsResponse {
+    #[serde(default)]
+    data: Vec<LlamaCppModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlamaCppModel {
+    id: String,
+}
+
+#[async_trait]
+impl RuntimeAdapter for LlamaCppAdapter {
+    fn id(&self) -> RuntimeId {
+        self.id.clone()
+    }
+
+    async fn inspect(&self) -> Result<RuntimeSnapshot, RuntimeError> {
+        let health_url = self
+            .base_url
+            .join("/health")
+            .map_err(|error| RuntimeError::Url(error.to_string()))?;
+        let health = self
+            .client
+            .get(health_url)
+            .headers(self.headers()?)
+            .send()
+            .await?;
+
+        if !health.status().is_success() {
+            return Ok(RuntimeSnapshot {
+                runtime_id: self.id.clone(),
+                available: false,
+                residents: Vec::new(),
+                configured_models: Vec::new(),
+                memory: RuntimeMemorySnapshot::default(),
+                active_requests: Vec::new(),
+            });
+        }
+
+        let configured_models = self.inspect_models().await?;
+
+        Ok(RuntimeSnapshot {
+            runtime_id: self.id.clone(),
+            available: true,
+            // /v1/models proves configuration, not residency — see
+            // docs/live_validation/residency-truth-contract.md. residents
+            // stays empty until we have evidence the model is loaded.
+            residents: Vec::new(),
+            configured_models,
+            memory: RuntimeMemorySnapshot::default(),
+            active_requests: Vec::new(),
+        })
+    }
+
+    async fn load_model(&self, _model: &ModelId) -> Result<LoadHandle, RuntimeError> {
+        Err(RuntimeError::Unsupported("llama-cpp load"))
+    }
+
+    async fn unload_model(&self, _model: &ModelId) -> Result<(), RuntimeError> {
+        Err(RuntimeError::Unsupported("llama-cpp unload"))
+    }
+
+    async fn execute(&self, _request: ExecutionRequest) -> Result<ExecutionHandle, RuntimeError> {
+        Err(RuntimeError::Unsupported("llama-cpp execute"))
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct LlamaSwapAdapter {
@@ -1125,6 +1266,176 @@ mod tests {
     #[test]
     fn ollama_base_url_validation_rejects_invalid_url() {
         let error = OllamaAdapter::new(RuntimeId("ollama".to_string()), "not a url")
+            .expect_err("invalid url");
+
+        assert!(error.to_string().contains("invalid runtime url"));
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_health_marks_runtime_available() {
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[]}"#),
+        ])
+        .await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert!(snapshot.available);
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_failed_health_marks_runtime_unavailable() {
+        let server = spawn_fixture(vec![http_response(500, "{}")]).await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert!(!snapshot.available);
+        assert!(snapshot.residents.is_empty());
+        assert!(snapshot.configured_models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_models_response_normalizes_model_ids() {
+        let server = spawn_fixture(vec![http_response(
+            200,
+            r#"{"data":[{"id":"models/qwen9b.gguf"},{"id":"granite8b"}]}"#,
+        )])
+        .await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let models = adapter.inspect_models().await.expect("models");
+
+        assert_eq!(
+            models,
+            vec![
+                ModelId("qwen9b".to_string()),
+                ModelId("granite8b".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_inspect_surfaces_configured_models_without_claiming_residency() {
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[{"id":"models/qwen9b.gguf"}]}"#),
+        ])
+        .await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert_eq!(snapshot.runtime_id, RuntimeId("llama_cpp".to_string()));
+        assert!(snapshot.available);
+        assert_eq!(
+            snapshot.configured_models,
+            vec![ModelId("qwen9b".to_string())]
+        );
+        assert!(
+            snapshot.residents.is_empty(),
+            "/v1/models proves configuration, not residency"
+        );
+        assert_eq!(snapshot.memory, RuntimeMemorySnapshot::default());
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_probe_uses_get_only() {
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[]}"#),
+        ])
+        .await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter");
+
+        let _ = adapter.inspect().await.expect("inspect");
+
+        let requests = server.requests.lock().expect("requests").clone();
+        for request_text in &requests {
+            assert!(
+                request_text.starts_with("GET"),
+                "inspect must use GET only, got: {request_text:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_load_unload_execute_are_unsupported() {
+        let adapter =
+            LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), "http://localhost:8080")
+                .expect("adapter");
+        let model = ModelId("qwen9b".to_string());
+
+        let load_error = adapter.load_model(&model).await.expect_err("load");
+        let unload_error = adapter.unload_model(&model).await.expect_err("unload");
+        let execute_error = adapter
+            .execute(ExecutionRequest {
+                request_id: RequestId::new(),
+                model_id: model,
+                prompt: None,
+            })
+            .await
+            .expect_err("execute");
+
+        assert_eq!(
+            load_error.to_string(),
+            "runtime operation is not supported: llama-cpp load"
+        );
+        assert_eq!(
+            unload_error.to_string(),
+            "runtime operation is not supported: llama-cpp unload"
+        );
+        assert_eq!(
+            execute_error.to_string(),
+            "runtime operation is not supported: llama-cpp execute"
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_auth_header_is_applied_when_configured() {
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[]}"#),
+        ])
+        .await;
+        let adapter = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), &server.base_url)
+            .expect("adapter")
+            .with_bearer_token("secret");
+
+        let _ = adapter.inspect().await.expect("snapshot");
+
+        let requests = server.requests.lock().expect("requests").clone();
+        assert_eq!(requests.len(), 2);
+        assert!(requests.iter().all(|request| request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer secret")));
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_timeout_returns_runtime_error() {
+        let base_url = spawn_timeout_server().await;
+        let adapter = LlamaCppAdapter::new_with_timeout(
+            RuntimeId("llama_cpp".to_string()),
+            &base_url,
+            Duration::from_millis(50),
+        )
+        .expect("adapter");
+
+        let error = adapter.inspect().await.expect_err("timeout");
+
+        assert!(matches!(error, RuntimeError::Http(error) if error.is_timeout()));
+    }
+
+    #[test]
+    fn llama_cpp_base_url_validation_rejects_invalid_url() {
+        let error = LlamaCppAdapter::new(RuntimeId("llama_cpp".to_string()), "not a url")
             .expect_err("invalid url");
 
         assert!(error.to_string().contains("invalid runtime url"));

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -55,3 +55,8 @@ opening `http://127.0.0.1:7071/health` and `http://localhost:7071/health`.
 - Full inference forwarding is intentionally not implemented in v1.
 - Live Ollama, llama-swap, and llama.cpp environments are not required for the
   mock-config demo and need separate live validation when used.
+- `LlamaCppAdapter` (`llama_cpp` / `llama_server`) is implemented and
+  fixture-tested as an inspect-only adapter (`/health` + `/v1/models` →
+  `configured_models`, empty residents). Live validation against a real
+  `llama-server` is pending — see
+  `docs/live_validation/llama-cpp-probe.md`.

--- a/docs/live_validation/llama-cpp-probe.md
+++ b/docs/live_validation/llama-cpp-probe.md
@@ -1,0 +1,91 @@
+# llama.cpp Read-Only Probe Procedure
+
+This procedure validates the `LlamaCppAdapter` (adapter id `llama_cpp` /
+`llama_server`) against a live `llama-server` instance. The adapter inspects
+only — it never loads, unloads, or executes.
+
+## Permission Boundary
+
+Read-only HTTP GET requests only. No POST, PUT, DELETE, or PATCH. This probe is
+covered by the read-only phase of [`safety-plan.md`](safety-plan.md) and does
+not require `ANEMOI_ENABLE_LIVE_EXECUTE=1`.
+
+## Required Inputs
+
+Set these environment variables before running the probe:
+
+```powershell
+$env:ANEMOI_LLAMA_CPP_BASE_URL = "http://127.0.0.1:8080"
+# Only if the endpoint requires authentication:
+$env:ANEMOI_LLAMA_CPP_AUTH_TOKEN = "<redacted>"
+```
+
+The auth token is read from the environment and expanded at config load. It is
+never committed.
+
+## Probe Steps
+
+### 1. Health Endpoint
+
+```powershell
+curl $env:ANEMOI_LLAMA_CPP_BASE_URL/health
+```
+
+Expected: HTTP 200. Confirms `llama-server` is reachable.
+
+### 2. Models Endpoint
+
+```powershell
+curl $env:ANEMOI_LLAMA_CPP_BASE_URL/v1/models
+```
+
+Expected: JSON with a `data` array of model objects. Each model has an `id`
+field.
+
+Note: `/v1/models` proves the model is **configured/served by the process**, not
+that Anemoi has independent evidence of GPU residency. Per the
+[residency truth contract](residency-truth-contract.md), Anemoi surfaces these
+ids as `configured_models` and does not claim hot residency.
+
+### 3. Anemoi Runtime Inspect
+
+```powershell
+cargo run -p anemoi-cli -- runtimes
+cargo run -p anemoi-cli -- residents
+```
+
+Expected: Runtime is listed with adapter `llama_cpp`. The `residents` array is
+empty (no false hot claims); configured models are surfaced separately.
+
+## Evidence Table
+
+Capture this information for each probe run:
+
+| Field | Value |
+|---|---|
+| Timestamp | `TBD` |
+| Runtime base URL | `TBD` |
+| Health HTTP status | `TBD` |
+| /v1/models response count | `TBD` |
+| Model IDs returned | `TBD` |
+| Anemoi interpretation | `TBD` |
+| Unexpected findings | `TBD` |
+| Needs validation | `TBD` |
+
+## Interpretation Rules
+
+| Endpoint Evidence | Anemoi Interpretation |
+|---|---|
+| Health returns 200, /v1/models returns models | Runtime is available. Models are configured. Residency is unknown (empty residents). |
+| Health returns non-200 | Runtime is unavailable. Empty residents and configured models. |
+| /v1/models returns empty data | Runtime is available with no configured models. |
+| /v1/models is not reachable but health is OK | `inspect()` returns an HTTP error; residency is unknown. |
+
+Do not claim hot residency unless a runtime-specific endpoint proves a model is
+currently loaded and serving.
+
+## Status
+
+**Needs validation.** Fixture tests in `crates/anemoi-runtime` cover the parsing
+and normalization contract. A live `llama-server` run against this procedure has
+not yet been recorded.

--- a/docs/live_validation/residency-truth-contract.md
+++ b/docs/live_validation/residency-truth-contract.md
@@ -64,6 +64,18 @@ This ensures Anemoi is conservative: unknown means cold until proven otherwise.
   rejected-options reasoning, but it must not contribute a hot-reuse
   bonus and it does not change the `Cold` residency state of any model.
 
-### HttpInspectAdapter (llama.cpp / llama_server)
+### LlamaCppAdapter (llama.cpp / llama_server)
+- `/health` confirms the process is reachable (maps to `available`).
+- `/v1/models` lists models served by the process but does **not** prove GPU
+  residency.
+- `inspect()` returns empty residents. Configured models remain `Cold`.
+- `inspect_models()` returns model IDs for reference, not residency.
+- The configured model list is surfaced on the snapshot as
+  `configured_models: Vec<ModelId>` — configuration evidence, not residency
+  evidence. It must not contribute a hot-reuse bonus.
+- The adapter inspects only: `load_model`, `unload_model`, and `execute` all
+  return `RuntimeError::Unsupported`.
+
+### HttpInspectAdapter (generic reachability probe)
 - Health check confirms process is reachable.
 - No model-level inspection is performed. All models are `Cold`.


### PR DESCRIPTION
## Summary
- Replace the `LlamaCppAdapter = HttpInspectAdapter` type alias with a proper `RuntimeAdapter` implementation that probes `/health` (availability) and `/v1/models` (configured model ids).
- Normalize model ids into `RuntimeSnapshot.configured_models` with **empty residents**, honoring the residency truth contract (`/v1/models` proves configuration, not residency).
- Inspect-only: `load_model`, `unload_model`, and `execute` return `RuntimeError::Unsupported`. `base_url` validated at construction; bearer token sourced from the environment.
- Daemon wires `llama_cpp`/`llama_server` to the new adapter with auth-token support (replacing `HttpInspectAdapter`, which remains as a generic reachability probe).
- Docs: new `docs/live_validation/llama-cpp-probe.md`, updated residency-truth-contract runtime section, and `docs/handoff.md` Needs Validation note.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] New fixture tests: `llama_cpp_health_marks_runtime_available`, `llama_cpp_failed_health_marks_runtime_unavailable`, `llama_cpp_models_response_normalizes_model_ids`, `llama_cpp_inspect_surfaces_configured_models_without_claiming_residency`, `llama_cpp_probe_uses_get_only`, `llama_cpp_load_unload_execute_are_unsupported`, `llama_cpp_auth_header_is_applied_when_configured`, `llama_cpp_timeout_returns_runtime_error`, `llama_cpp_base_url_validation_rejects_invalid_url`
- [ ] Live validation against a real `llama-server` (tracked as Needs Validation)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)