### PR TITLE
feat(policy): add eviction and pinning policy (Closes #31)

### DIFF
--- a/crates/anemoi-core/src/lib.rs
+++ b/crates/anemoi-core/src/lib.rs
@@ -143,6 +143,9 @@ pub struct ResidencyGroup {
     pub models: Vec<ModelId>,
     pub keep_hot: bool,
     pub allow_background_load: bool,
+    /// Pinned groups are protected from eviction unless a force policy
+    /// explicitly overrides protection.
+    pub pinned: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -311,6 +314,18 @@ impl ActionPlan {
         });
     }
 
+    pub fn add_unload(&mut self, runtime_id: RuntimeId, model_id: ModelId, reason: String) {
+        self.actions.push(RuntimeAction {
+            kind: ActionKind::Unload,
+            runtime_id,
+            model_id: Some(model_id),
+            is_foreground: true,
+            is_mutating: true,
+            reason,
+            expected_cost_ms: None,
+        });
+    }
+
     pub fn add_noop(&mut self, runtime_id: RuntimeId, reason: String) {
         self.actions.push(RuntimeAction {
             kind: ActionKind::NoOp,
@@ -462,6 +477,8 @@ pub struct ResidencyGroupConfig {
     pub keep_hot: bool,
     #[serde(default)]
     pub allow_background_load: bool,
+    #[serde(default)]
+    pub pinned: bool,
 }
 
 impl ResidencyGroupConfig {
@@ -472,6 +489,7 @@ impl ResidencyGroupConfig {
             models: self.models,
             keep_hot: self.keep_hot,
             allow_background_load: self.allow_background_load,
+            pinned: self.pinned,
         }
     }
 }
@@ -526,6 +544,11 @@ impl AnemoiConfig {
     pub fn from_yaml_file_raw(path: impl AsRef<std::path::Path>) -> Result<Self, ConfigError> {
         let text = std::fs::read_to_string(path)?;
         Ok(serde_yaml::from_str(&text)?)
+    }
+
+    pub fn from_yaml_str(text: &str) -> Result<Self, ConfigError> {
+        let expanded = expand_env_vars(text);
+        Ok(serde_yaml::from_str(&expanded)?)
     }
 
     pub fn validate(&self) -> Result<(), ConfigValidationError> {

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -1,8 +1,8 @@
 use anemoi_core::{
     ActionKind, ActionPlan, AnemoiConfig, Decision, DecisionAction, InferenceRequest, ModelId,
-    ModelResident, RuntimeId, RuntimeSnapshot,
+    ModelResident, ResidencyState, RuntimeId, RuntimeSnapshot,
 };
-use anemoi_policy::Scheduler;
+use anemoi_policy::{EvictionCandidateResident, EvictionPlan, EvictionRequest, Scheduler};
 use anemoi_runtime::{
     DynRuntimeAdapter, LlamaCppAdapter, LlamaSwapAdapter, MockRuntimeAdapter, OllamaAdapter,
 };
@@ -579,6 +579,95 @@ impl AppState {
                         }
                     }
                 }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Build an eviction plan from the reconciled cache and configured policy.
+    /// Pure read of governance state — never mutates a runtime.
+    pub async fn plan_evictions(&self, force: bool) -> EvictionPlan {
+        let snapshots = self.reconciler.get_snapshots().await;
+        let now = chrono::Utc::now();
+
+        let mut residents = Vec::new();
+        for snapshot in &snapshots {
+            for resident in &snapshot.residents {
+                let (keep_hot, pinned) = self.group_protection(&resident.model_id);
+                let serving = snapshot
+                    .active_requests
+                    .iter()
+                    .any(|active| active.model_id == resident.model_id);
+                let state = if serving {
+                    ResidencyState::Serving
+                } else {
+                    resident.state.clone()
+                };
+                let idle_secs = resident
+                    .loaded_since
+                    .map(|since| (now - since).num_seconds().max(0) as u64);
+                residents.push(EvictionCandidateResident {
+                    model_id: resident.model_id.clone(),
+                    runtime_id: snapshot.runtime_id.clone(),
+                    state,
+                    keep_hot,
+                    pinned,
+                    idle_secs,
+                });
+            }
+        }
+
+        anemoi_policy::plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force,
+        })
+    }
+
+    fn group_protection(&self, model_id: &ModelId) -> (bool, bool) {
+        let mut keep_hot = false;
+        let mut pinned = false;
+        for group in self.config.residency_groups.values() {
+            if group.models.contains(model_id) {
+                keep_hot |= group.keep_hot;
+                pinned |= group.pinned;
+            }
+        }
+        (keep_hot, pinned)
+    }
+
+    /// Execute the unload actions in an eviction plan. Mock runtimes execute
+    /// when the plan is approved; non-mock runtimes additionally require
+    /// `ANEMOI_ENABLE_LIVE_EXECUTE=1`. Dry-run or unapproved plans do nothing.
+    pub async fn execute_eviction_plan(
+        &self,
+        plan: &ActionPlan,
+        approved: bool,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut results = Vec::new();
+
+        if plan.dry_run || !approved {
+            return Ok(results);
+        }
+
+        for action in &plan.actions {
+            if action.kind != ActionKind::Unload {
+                continue;
+            }
+            let Some(model_id) = &action.model_id else {
+                continue;
+            };
+
+            let is_mock = self.runtime_adapter_type(&action.runtime_id.to_string()) == Some("mock");
+            if !is_mock && !live_execution_enabled() {
+                return Err(anyhow::anyhow!(
+                    "Live eviction requires ANEMOI_ENABLE_LIVE_EXECUTE=1"
+                ));
+            }
+
+            if let Some(runtime) = self.runtimes.get(&action.runtime_id.to_string()) {
+                runtime.unload_model(model_id).await?;
+                results.push(format!("Unloaded {} on {}", model_id, action.runtime_id));
             }
         }
 
@@ -1514,6 +1603,90 @@ mod tests {
         assert!(
             result.is_err(),
             "live execution should fail without ANEMOI_ENABLE_LIVE_EXECUTE=1"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_eviction_executes_unload_action_when_plan_is_approved() {
+        let state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+
+        // The example mock runtime starts with qwen9b resident.
+        let before = state.snapshots().await;
+        assert!(
+            before.iter().any(|snapshot| snapshot
+                .residents
+                .iter()
+                .any(|resident| resident.model_id == ModelId("qwen9b".to_string()))),
+            "qwen9b should be resident before eviction"
+        );
+
+        let mut plan = ActionPlan::new(Uuid::new_v4(), false);
+        plan.add_unload(
+            RuntimeId("mock".to_string()),
+            ModelId("qwen9b".to_string()),
+            "approved eviction".to_string(),
+        );
+
+        let results = state
+            .execute_eviction_plan(&plan, true)
+            .await
+            .expect("mock eviction should execute");
+        assert!(
+            results.iter().any(|line| line.contains("qwen9b")),
+            "eviction result should report unloading qwen9b"
+        );
+
+        let after = state.snapshots().await;
+        assert!(
+            !after.iter().any(|snapshot| snapshot
+                .residents
+                .iter()
+                .any(|resident| resident.model_id == ModelId("qwen9b".to_string()))),
+            "qwen9b should no longer be resident after approved mock eviction"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_eviction_requires_explicit_enable_flag() {
+        let config = AnemoiConfig::from_yaml_str(
+            r#"
+domains:
+  coding:
+    rosters: [pool]
+residency_groups:
+  pool:
+    models: [qwen9b]
+models:
+  qwen9b:
+    family: qwen
+    parameter_class: 9b
+    context_window: 32768
+    vram_required_mb: 9000
+    ram_required_mb: 12000
+    cold_load_estimate_ms: 18000
+    supported_runtimes: [live]
+runtimes:
+  live:
+    adapter: ollama
+    base_url: http://127.0.0.1:11434
+"#,
+        )
+        .expect("valid config");
+
+        let state = AppState::new(config, Arc::new(InMemoryDecisionLog::default())).expect("state");
+
+        let mut plan = ActionPlan::new(Uuid::new_v4(), false);
+        plan.add_unload(
+            RuntimeId("live".to_string()),
+            ModelId("qwen9b".to_string()),
+            "operator eviction".to_string(),
+        );
+
+        let result = state.execute_eviction_plan(&plan, true).await;
+        assert!(
+            result.is_err(),
+            "live (non-mock) eviction must fail without ANEMOI_ENABLE_LIVE_EXECUTE=1"
         );
     }
 

--- a/crates/anemoi-policy/src/eviction.rs
+++ b/crates/anemoi-policy/src/eviction.rs
@@ -1,0 +1,149 @@
+//! Eviction and pinning policy.
+//!
+//! Decides which residents may be evicted to free capacity. Eviction is
+//! explainable and conservative by default: keep-hot continuity workers and
+//! pinned models are protected, and actively serving models are blocked unless
+//! a force policy explicitly overrides protection. The planner never mutates a
+//! runtime — it only produces candidates, protections, and blocks for the
+//! controlled execution path to act on.
+
+use anemoi_core::{DecisionReason, ModelId, ResidencyState, RuntimeId};
+
+/// A resident under consideration for eviction, with the policy-relevant flags
+/// already resolved from config and runtime state.
+#[derive(Debug, Clone)]
+pub struct EvictionCandidateResident {
+    pub model_id: ModelId,
+    pub runtime_id: RuntimeId,
+    pub state: ResidencyState,
+    /// Member of a keep-hot continuity group.
+    pub keep_hot: bool,
+    /// Member of a pinned residency group.
+    pub pinned: bool,
+    /// Idle time in seconds; higher means a better eviction candidate.
+    /// `None` means idle time is unknown.
+    pub idle_secs: Option<u64>,
+}
+
+impl EvictionCandidateResident {
+    fn is_serving(&self) -> bool {
+        matches!(self.state, ResidencyState::Serving)
+    }
+}
+
+/// Inputs to the eviction planner.
+#[derive(Debug, Clone)]
+pub struct EvictionRequest<'a> {
+    pub residents: &'a [EvictionCandidateResident],
+    /// When set, the force policy overrides keep-hot, pinning, and serving
+    /// protections. Used only for explicit operator-driven eviction.
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvictionCandidate {
+    pub model_id: ModelId,
+    pub runtime_id: RuntimeId,
+    pub idle_secs: Option<u64>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtectedResident {
+    pub model_id: ModelId,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockedEviction {
+    pub model_id: ModelId,
+    pub reason: String,
+}
+
+/// The outcome of eviction planning: ranked candidates, protected residents,
+/// blocked residents, and the structured reasons that explain each decision.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EvictionPlan {
+    pub candidates: Vec<EvictionCandidate>,
+    pub protected: Vec<ProtectedResident>,
+    pub blocked: Vec<BlockedEviction>,
+    pub reasons: Vec<DecisionReason>,
+}
+
+impl EvictionPlan {
+    pub fn is_empty(&self) -> bool {
+        self.candidates.is_empty()
+    }
+}
+
+/// Plan evictions over the supplied residents. Pure and side-effect free.
+pub fn plan_evictions(request: &EvictionRequest<'_>) -> EvictionPlan {
+    let mut plan = EvictionPlan::default();
+
+    for resident in request.residents {
+        let model = &resident.model_id;
+
+        if resident.keep_hot && !request.force {
+            plan.protected.push(ProtectedResident {
+                model_id: model.clone(),
+                reason: "keep-hot continuity worker is protected from eviction".to_string(),
+            });
+            plan.reasons.push(DecisionReason {
+                code: "eviction.protected.keep_hot".to_string(),
+                detail: format!("{model} is protected as a keep-hot continuity worker"),
+                impact: 0,
+            });
+            continue;
+        }
+
+        if resident.pinned && !request.force {
+            plan.protected.push(ProtectedResident {
+                model_id: model.clone(),
+                reason: "pinned model is protected from eviction".to_string(),
+            });
+            plan.reasons.push(DecisionReason {
+                code: "eviction.protected.pinned".to_string(),
+                detail: format!("{model} is protected because its residency group is pinned"),
+                impact: 0,
+            });
+            continue;
+        }
+
+        if resident.is_serving() && !request.force {
+            plan.blocked.push(BlockedEviction {
+                model_id: model.clone(),
+                reason: "model is actively serving; eviction requires a force policy".to_string(),
+            });
+            plan.reasons.push(DecisionReason {
+                code: "eviction.blocked.serving".to_string(),
+                detail: format!("{model} is actively serving and cannot be evicted without force"),
+                impact: 0,
+            });
+            continue;
+        }
+
+        plan.candidates.push(EvictionCandidate {
+            model_id: model.clone(),
+            runtime_id: resident.runtime_id.clone(),
+            idle_secs: resident.idle_secs,
+            reason: "idle, unpinned resident eligible for eviction".to_string(),
+        });
+        plan.reasons.push(DecisionReason {
+            code: "eviction.candidate".to_string(),
+            detail: format!("{model} is an eligible eviction candidate"),
+            impact: 0,
+        });
+    }
+
+    // Prefer the most idle candidate first; unknown idle ranks last. Ties break
+    // on model id for determinism.
+    plan.candidates.sort_by(|a, b| {
+        let a_key = a.idle_secs.unwrap_or(0);
+        let b_key = b.idle_secs.unwrap_or(0);
+        b_key
+            .cmp(&a_key)
+            .then_with(|| a.model_id.to_string().cmp(&b.model_id.to_string()))
+    });
+
+    plan
+}

--- a/crates/anemoi-policy/src/lib.rs
+++ b/crates/anemoi-policy/src/lib.rs
@@ -8,7 +8,12 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use uuid::Uuid;
 
+mod eviction;
 mod pressure;
+pub use eviction::{
+    plan_evictions, BlockedEviction, EvictionCandidate, EvictionCandidateResident, EvictionPlan,
+    EvictionRequest, ProtectedResident,
+};
 pub use pressure::{Pressure, PressureAssessment, PressureInputs, PressureModel, PressureReason};
 
 #[derive(Debug, thiserror::Error)]
@@ -1031,6 +1036,162 @@ continuity:
             .reasons
             .iter()
             .any(|reason| { reason.code.contains("active_request") && reason.impact < 0 }));
+    }
+
+    fn eviction_resident(
+        id: &str,
+        state: ResidencyState,
+        keep_hot: bool,
+        pinned: bool,
+        idle_secs: Option<u64>,
+    ) -> EvictionCandidateResident {
+        EvictionCandidateResident {
+            model_id: ModelId(id.to_string()),
+            runtime_id: RuntimeId("mock".to_string()),
+            state,
+            keep_hot,
+            pinned,
+            idle_secs,
+        }
+    }
+
+    #[test]
+    fn keep_hot_group_members_are_not_evicted_for_background_stage() {
+        let residents = vec![
+            eviction_resident(
+                "small_worker",
+                ResidencyState::HotGpu,
+                true,
+                false,
+                Some(10),
+            ),
+            eviction_resident("big_idle", ResidencyState::HotGpu, false, false, Some(600)),
+        ];
+
+        let plan = plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force: false,
+        });
+
+        assert!(
+            plan.protected
+                .iter()
+                .any(|protected| protected.model_id == ModelId("small_worker".to_string())),
+            "keep-hot worker must be protected"
+        );
+        assert!(
+            !plan
+                .candidates
+                .iter()
+                .any(|candidate| candidate.model_id == ModelId("small_worker".to_string())),
+            "keep-hot worker must not be an eviction candidate"
+        );
+    }
+
+    #[test]
+    fn eviction_plan_prefers_unpinned_idle_resident() {
+        let residents = vec![
+            eviction_resident(
+                "pinned_worker",
+                ResidencyState::HotGpu,
+                false,
+                true,
+                Some(9_999),
+            ),
+            eviction_resident(
+                "recent_resident",
+                ResidencyState::HotGpu,
+                false,
+                false,
+                Some(5),
+            ),
+            eviction_resident(
+                "idle_resident",
+                ResidencyState::HotGpu,
+                false,
+                false,
+                Some(900),
+            ),
+        ];
+
+        let plan = plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force: false,
+        });
+
+        assert!(
+            plan.protected
+                .iter()
+                .any(|protected| protected.model_id == ModelId("pinned_worker".to_string())),
+            "pinned worker must be protected, not a candidate"
+        );
+        assert_eq!(
+            plan.candidates.first().map(|candidate| &candidate.model_id),
+            Some(&ModelId("idle_resident".to_string())),
+            "the most-idle unpinned resident should rank first"
+        );
+    }
+
+    #[test]
+    fn eviction_plan_rejects_serving_model_without_force_policy() {
+        let residents = vec![eviction_resident(
+            "serving_model",
+            ResidencyState::Serving,
+            false,
+            false,
+            Some(0),
+        )];
+
+        let plan = plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force: false,
+        });
+
+        assert!(
+            plan.blocked
+                .iter()
+                .any(|blocked| blocked.model_id == ModelId("serving_model".to_string())),
+            "a serving model must be blocked without force"
+        );
+        assert!(
+            plan.candidates.is_empty(),
+            "a serving model must not be an eviction candidate without force"
+        );
+
+        let forced = plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force: true,
+        });
+        assert!(
+            forced
+                .candidates
+                .iter()
+                .any(|candidate| candidate.model_id == ModelId("serving_model".to_string())),
+            "force policy must allow evicting a serving model"
+        );
+    }
+
+    #[test]
+    fn pinning_policy_explanation_names_protected_model() {
+        let residents = vec![eviction_resident(
+            "pinned_model",
+            ResidencyState::HotGpu,
+            false,
+            true,
+            Some(120),
+        )];
+
+        let plan = plan_evictions(&EvictionRequest {
+            residents: &residents,
+            force: false,
+        });
+
+        assert!(
+            plan.reasons.iter().any(|reason| {
+                reason.code.contains("pinned") && reason.detail.contains("pinned_model")
+            }),
+            "explanation must name the protected pinned model"
+        );
     }
 
     fn candidate_request() -> InferenceRequest {

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -45,7 +45,7 @@ hardening when the local toolchain has the `clippy` component installed.
 | 22 background staging worker | Stage recommendations become observable staging intents and mock-executable jobs. | `anemoi-core`, `anemoi-daemon`, `anemoi-policy` | Passing |
 | 23 load/unload action plan | Decisions produce explicit dry-run action plans before runtime mutation. | `anemoi-core`, `anemoi-daemon`, `anemoi-runtime` | Passing |
 | 24 resource pressure model | Candidate scoring uses explicit VRAM, RAM, KV, load, and active-request pressure evidence. | `anemoi-policy`, `anemoi-core` | Passing |
-| 25 eviction and pinning policy | Keep-hot workers are protected and eviction plans are explainable and gated. | `anemoi-policy`, `anemoi-core`, `anemoi-runtime` | Pending |
+| 25 eviction and pinning policy | Keep-hot workers are protected and eviction plans are explainable and gated. | `anemoi-policy`, `anemoi-core`, `anemoi-runtime` | Passing |
 | 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Pending |
 | 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Pending |
 | 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Pending |


### PR DESCRIPTION
## Summary
- Adds an explainable eviction planner in `anemoi-policy` (`eviction.rs`): keep-hot continuity workers and pinned residency groups are protected, actively serving models are blocked unless a `force` policy overrides, and the remaining unpinned residents are ranked as eviction candidates (most idle first).
- Adds a `pinned` flag to residency group config (`anemoi-core`), an `ActionPlan::add_unload` builder, and a `from_yaml_str` config helper.
- Adds a daemon execution path: `execute_eviction_plan(plan, approved)` runs `Unload` actions — mock runtimes evict when the plan is approved; non-mock runtimes still require `ANEMOI_ENABLE_LIVE_EXECUTE=1`. `AppState::plan_evictions` builds the plan from the reconciled cache + configured protections (keep-hot/pinned/serving), so the planner is production-reachable, not test-only.
- Flips the prompt 25 row in `docs/test_roadmap.md` to Passing.

## Test plan
- [x] `cargo test --workspace` — 6 new required tests pass: `keep_hot_group_members_are_not_evicted_for_background_stage`, `eviction_plan_prefers_unpinned_idle_resident`, `eviction_plan_rejects_serving_model_without_force_policy`, `pinning_policy_explanation_names_protected_model`, `mock_eviction_executes_unload_action_when_plan_is_approved`, `live_eviction_requires_explicit_enable_flag`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)