### PR TITLE
feat(daemon): consolidated operator status surface (Closes #32)

### DIFF
--- a/crates/anemoi-cli/src/main.rs
+++ b/crates/anemoi-cli/src/main.rs
@@ -2,7 +2,7 @@ use anemoi_core::{
     validate_config, AnemoiConfig, DiagnosticSeverity, DomainId, ExecutionMode, InferenceRequest,
     RequestId,
 };
-use anemoi_daemon::AppState;
+use anemoi_daemon::{AppState, OperatorStatus};
 use anemoi_telemetry::default_decision_log;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -88,13 +88,10 @@ async fn run(args: Args) -> anyhow::Result<String> {
 
     match args.command {
         Command::Status => {
-            output.push_str(&format!("Domains: {}\n", config.domains.len()));
-            output.push_str(&format!("Models: {}\n", config.models.len()));
-            output.push_str(&format!("Runtimes: {}\n", config.runtimes.len()));
-            output.push_str(&format!(
-                "Residency groups: {}\n",
-                config.residency_groups.len()
-            ));
+            // One reconciliation tick to populate the cache, then report purely
+            // from the reconciled snapshot — no further live inspection.
+            state.run_reconciliation_tick().await;
+            output.push_str(&format_status(&state.operator_status().await));
         }
         Command::Residents => {
             let snapshots = state.snapshots().await;
@@ -156,6 +153,108 @@ fn format_policy_check(config: &AnemoiConfig) -> String {
     output
 }
 
+fn format_status(status: &OperatorStatus) -> String {
+    let mut output = String::from("Anemoi operator status\n======================\n");
+
+    output.push_str(&format!(
+        "Live execution: {}\n",
+        if status.live_execution_enabled {
+            "enabled"
+        } else {
+            "disabled (ANEMOI_ENABLE_LIVE_EXECUTE not set)"
+        }
+    ));
+    output.push_str(&format!(
+        "Reconciliation cache: {}\n",
+        if status.cache_populated {
+            "populated"
+        } else {
+            "empty (governance state unknown until first inspection)"
+        }
+    ));
+    output.push_str(&format!(
+        "Active requests: {}\n",
+        status.active_request_count
+    ));
+    output.push_str(&format!(
+        "Recent decisions: {}\n",
+        status.recent_decision_count
+    ));
+
+    output.push_str("\nRuntimes:\n");
+    for runtime in &status.runtimes {
+        output.push_str(&format!(
+            "  {} ({}): availability={}, freshness={}\n",
+            runtime.runtime_id, runtime.adapter, runtime.availability, runtime.freshness
+        ));
+        if let Some(error) = &runtime.last_error {
+            output.push_str(&format!("    last error: {error}\n"));
+        }
+        output.push_str(&format!(
+            "    active requests: {}\n",
+            runtime.active_request_count
+        ));
+        if runtime.residents.is_empty() {
+            output.push_str("    residents: none observed\n");
+        } else {
+            output.push_str("    residents:\n");
+            for resident in &runtime.residents {
+                let idle = resident
+                    .idle_secs
+                    .map(|s| format!("{s}s"))
+                    .unwrap_or_else(|| "unknown".to_string());
+                output.push_str(&format!(
+                    "      - {} [{}] idle: {}\n",
+                    resident.model_id,
+                    format_residency_state(&resident.state),
+                    idle
+                ));
+            }
+        }
+    }
+
+    output.push_str("\nResidency groups:\n");
+    for group in &status.residency_groups {
+        let flags = match (group.keep_hot, group.pinned) {
+            (true, true) => "keep-hot, pinned",
+            (true, false) => "keep-hot",
+            (false, true) => "pinned",
+            (false, false) => "no protection",
+        };
+        output.push_str(&format!(
+            "  {}: {} ({}, {}/{} hot)\n",
+            group.group_id, group.health, flags, group.hot_resident_count, group.member_count
+        ));
+    }
+
+    output.push_str(&format!(
+        "\nStaging queue: total {} (blocked {}, pending {}, failed {}, completed {})\n",
+        status.staging.total,
+        status.staging.blocked,
+        status.staging.pending,
+        status.staging.failed,
+        status.staging.completed
+    ));
+
+    output.push_str("\nPolicy warnings:\n");
+    if status.policy_warnings.is_empty() {
+        output.push_str("  none\n");
+    } else {
+        for warning in &status.policy_warnings {
+            output.push_str(&format!("  - {warning}\n"));
+        }
+    }
+
+    output
+}
+
+fn format_residency_state(state: &anemoi_core::ResidencyState) -> String {
+    serde_json::to_value(state)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{state:?}"))
+}
+
 fn format_decision(decision: &anemoi_core::Decision) -> String {
     let mut output = String::new();
     output.push_str(&format!(
@@ -188,13 +287,47 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn cli_status_prints_configured_counts() {
+    async fn cli_status_prints_residents_staging_and_policy_summary() {
         let output = run_cli(["anemoi", "--config", &example_config_path(), "status"]).await;
 
-        assert!(output.contains("Domains: 1"));
-        assert!(output.contains("Models: 3"));
-        assert!(output.contains("Runtimes: 1"));
-        assert!(output.contains("Residency groups: 2"));
+        // Residents observed from the reconciled cache.
+        assert!(output.contains("mock"), "runtime should be listed");
+        assert!(output.contains("qwen9b"), "resident model should be listed");
+        assert!(
+            output.contains("hot_gpu"),
+            "resident state should be listed"
+        );
+
+        // Residency group health.
+        assert!(output.contains("small_swarm"));
+        assert!(output.contains("large_models"));
+
+        // Staging queue summary.
+        assert!(output.to_lowercase().contains("staging queue"));
+
+        // Policy / governance summary.
+        assert!(output.to_lowercase().contains("policy warnings"));
+        assert!(output.to_lowercase().contains("live execution"));
+    }
+
+    #[tokio::test]
+    async fn cli_status_marks_unknown_and_stale_state_plainly() {
+        let config = AnemoiConfig::from_yaml_file(example_config_path()).expect("config");
+        let state = AppState::new(config, Arc::new(InMemoryDecisionLog::default())).expect("state");
+
+        state.run_reconciliation_tick().await;
+        state.reconciler().mark_stale().await;
+
+        let output = format_status(&state.operator_status().await);
+        let lower = output.to_lowercase();
+
+        // Aged snapshot is plainly labeled stale, not silently treated as fresh.
+        assert!(lower.contains("stale"), "stale state must be labeled");
+        // Mock residents have no known load time, so idle is plainly unknown.
+        assert!(
+            lower.contains("unknown"),
+            "unknown state must be labeled, not omitted"
+        );
     }
 
     #[tokio::test]

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -110,7 +110,7 @@ impl Reconciler {
             let elapsed = Utc::now()
                 .signed_duration_since(r.last_inspected)
                 .num_milliseconds();
-            r.is_stale = elapsed > self.ttl_ms as i64;
+            r.is_stale = r.is_stale || elapsed > self.ttl_ms as i64;
         }
         reconciled
     }
@@ -124,7 +124,7 @@ impl Reconciler {
                 let elapsed = Utc::now()
                     .signed_duration_since(r.last_inspected)
                     .num_milliseconds();
-                r.is_stale = elapsed > self.ttl_ms as i64;
+                r.is_stale = r.is_stale || elapsed > self.ttl_ms as i64;
                 r
             })
             .collect()
@@ -300,6 +300,91 @@ impl Default for StagingWorker {
     }
 }
 
+/// Consolidated operator-facing view of all governance state, derived purely
+/// from the reconciled snapshot cache, configuration, staging queue, and
+/// decision log. Missing or aged data is labeled explicitly rather than
+/// silently omitted — see [`RuntimeStatus::freshness`] and unknown labels.
+#[derive(Debug, Clone, Serialize)]
+pub struct OperatorStatus {
+    /// Whether the reconciliation cache has any inspected runtimes yet.
+    pub cache_populated: bool,
+    /// One entry per configured runtime, including those never inspected.
+    pub runtimes: Vec<RuntimeStatus>,
+    /// Health of each configured residency group.
+    pub residency_groups: Vec<GroupHealth>,
+    /// Active inference requests observed across all runtimes.
+    pub active_request_count: usize,
+    /// Background staging queue summary.
+    pub staging: StagingSummary,
+    /// Number of decisions retained in the decision log.
+    pub recent_decision_count: usize,
+    /// Human-readable policy warnings (e.g. keep-hot group with no hot resident).
+    pub policy_warnings: Vec<String>,
+    /// Whether `ANEMOI_ENABLE_LIVE_EXECUTE=1` is set (live runtime mutation).
+    pub live_execution_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeStatus {
+    pub runtime_id: String,
+    pub adapter: String,
+    /// `"available"`, `"unavailable"`, or `"unknown"` (never inspected).
+    pub availability: String,
+    /// `"fresh"`, `"stale"`, or `"unknown"` (never inspected).
+    pub freshness: String,
+    pub last_inspected: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+    pub active_request_count: usize,
+    pub residents: Vec<ResidentStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResidentStatus {
+    pub model_id: String,
+    pub state: ResidencyState,
+    /// Idle seconds since load; `None` means idle time is unknown.
+    pub idle_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GroupHealth {
+    pub group_id: String,
+    pub keep_hot: bool,
+    pub pinned: bool,
+    pub member_count: usize,
+    pub hot_resident_count: usize,
+    /// `"healthy"`, `"degraded"` (keep-hot group with no hot residents), or
+    /// `"unknown"` (no reconciled data yet).
+    pub health: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct StagingSummary {
+    pub total: usize,
+    pub blocked: usize,
+    pub pending: usize,
+    pub failed: usize,
+    pub completed: usize,
+}
+
+impl StagingSummary {
+    fn from_intents(intents: &[StagingIntent]) -> Self {
+        let mut summary = StagingSummary {
+            total: intents.len(),
+            ..StagingSummary::default()
+        };
+        for intent in intents {
+            match intent.state {
+                StagingState::Blocked => summary.blocked += 1,
+                StagingState::Pending => summary.pending += 1,
+                StagingState::Failed => summary.failed += 1,
+                StagingState::Completed => summary.completed += 1,
+            }
+        }
+        summary
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     config: AnemoiConfig,
@@ -439,6 +524,141 @@ impl AppState {
             }
         }
         snapshots
+    }
+
+    /// Build the consolidated operator status view from the reconciled cache,
+    /// configuration, staging queue, and decision log. Read-only: never
+    /// triggers live runtime inspection.
+    pub async fn operator_status(&self) -> OperatorStatus {
+        let reconciled = self.reconciler.all().await;
+        let cache_populated = !reconciled.is_empty();
+
+        let mut by_runtime: HashMap<String, ReconciledSnapshot> = HashMap::new();
+        for r in reconciled {
+            by_runtime.insert(r.snapshot.runtime_id.to_string(), r);
+        }
+
+        let now = Utc::now();
+        let mut runtimes = Vec::new();
+        let mut active_request_count = 0usize;
+
+        let mut runtime_ids: Vec<String> =
+            self.config.runtimes.keys().map(|k| k.to_string()).collect();
+        runtime_ids.sort();
+
+        for runtime_id in runtime_ids {
+            let adapter = self
+                .runtime_adapter_type(&runtime_id)
+                .unwrap_or("unknown")
+                .to_string();
+
+            match by_runtime.get(&runtime_id) {
+                Some(r) => {
+                    let availability = if r.snapshot.available {
+                        "available"
+                    } else {
+                        "unavailable"
+                    }
+                    .to_string();
+                    let freshness = if r.is_stale { "stale" } else { "fresh" }.to_string();
+                    let residents = r
+                        .snapshot
+                        .residents
+                        .iter()
+                        .map(|res| ResidentStatus {
+                            model_id: res.model_id.to_string(),
+                            state: res.state.clone(),
+                            idle_secs: res
+                                .loaded_since
+                                .map(|since| (now - since).num_seconds().max(0) as u64),
+                        })
+                        .collect();
+                    let active = r.snapshot.active_requests.len();
+                    active_request_count += active;
+                    runtimes.push(RuntimeStatus {
+                        runtime_id,
+                        adapter,
+                        availability,
+                        freshness,
+                        last_inspected: Some(r.last_inspected),
+                        last_error: r.last_error.clone(),
+                        active_request_count: active,
+                        residents,
+                    });
+                }
+                None => {
+                    runtimes.push(RuntimeStatus {
+                        runtime_id,
+                        adapter,
+                        availability: "unknown".to_string(),
+                        freshness: "unknown".to_string(),
+                        last_inspected: None,
+                        last_error: None,
+                        active_request_count: 0,
+                        residents: Vec::new(),
+                    });
+                }
+            }
+        }
+
+        let hot_models: std::collections::HashSet<String> = by_runtime
+            .values()
+            .flat_map(|r| r.snapshot.residents.iter())
+            .filter(|res| matches!(res.state, ResidencyState::HotGpu | ResidencyState::Serving))
+            .map(|res| res.model_id.to_string())
+            .collect();
+
+        let mut residency_groups = Vec::new();
+        let mut policy_warnings = Vec::new();
+        let mut group_ids: Vec<_> = self.config.residency_groups.keys().cloned().collect();
+        group_ids.sort_by_key(|g| g.to_string());
+        for group_id in group_ids {
+            let group = &self.config.residency_groups[&group_id];
+            let hot_resident_count = group
+                .models
+                .iter()
+                .filter(|m| hot_models.contains(&m.to_string()))
+                .count();
+            let degraded = group.keep_hot && hot_resident_count == 0;
+            let health = if !cache_populated {
+                "unknown"
+            } else if degraded {
+                "degraded"
+            } else {
+                "healthy"
+            }
+            .to_string();
+            if cache_populated && degraded {
+                policy_warnings.push(format!("keep-hot group '{group_id}' has no hot residents"));
+            }
+            residency_groups.push(GroupHealth {
+                group_id: group_id.to_string(),
+                keep_hot: group.keep_hot,
+                pinned: group.pinned,
+                member_count: group.models.len(),
+                hot_resident_count,
+                health,
+            });
+        }
+
+        let staging = StagingSummary::from_intents(&self.staging_worker.get_all().await);
+        let recent_decision_count = self
+            .decision_log
+            .list_decisions()
+            .await
+            .map(|d| d.len())
+            .unwrap_or(0);
+
+        OperatorStatus {
+            cache_populated,
+            runtimes,
+            residency_groups,
+            active_request_count,
+            staging,
+            recent_decision_count,
+            policy_warnings,
+            live_execution_enabled: live_execution_enabled(),
+        }
     }
 
     pub async fn decide(&self, request: &InferenceRequest) -> anyhow::Result<Decision> {
@@ -766,7 +986,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn status_returns_configured_counts() {
+    async fn status_returns_operator_summary() {
         let response = test_router()
             .oneshot(
                 Request::builder()
@@ -779,10 +999,11 @@ mod tests {
 
         let body = json_body(response).await;
 
-        assert_eq!(body["domains"], 1);
-        assert_eq!(body["models"], 3);
-        assert_eq!(body["runtimes"], 1);
-        assert_eq!(body["residency_groups"], 2);
+        assert!(body["runtimes"].is_array());
+        assert!(body["residency_groups"].is_array());
+        assert!(body["staging"].is_object());
+        assert!(body["recent_decision_count"].is_number());
+        assert!(body["live_execution_enabled"].is_boolean());
     }
 
     #[tokio::test]
@@ -1278,6 +1499,89 @@ mod tests {
             !snapshots.is_empty(),
             "reconciled snapshots should be available"
         );
+    }
+
+    #[tokio::test]
+    async fn status_summary_includes_runtime_availability_and_staleness() {
+        let state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+
+        // Before any inspection, availability and freshness are explicitly
+        // unknown — never silently omitted.
+        let cold = state.operator_status().await;
+        assert!(!cold.cache_populated);
+        let mock_cold = cold
+            .runtimes
+            .iter()
+            .find(|r| r.runtime_id == "mock")
+            .expect("mock runtime listed even when uninspected");
+        assert_eq!(mock_cold.availability, "unknown");
+        assert_eq!(mock_cold.freshness, "unknown");
+        assert!(mock_cold.last_inspected.is_none());
+
+        state.run_reconciliation_tick().await;
+        let fresh = state.operator_status().await;
+        let mock_fresh = fresh
+            .runtimes
+            .iter()
+            .find(|r| r.runtime_id == "mock")
+            .expect("mock runtime");
+        assert_eq!(mock_fresh.availability, "available");
+        assert_eq!(mock_fresh.freshness, "fresh");
+        assert!(mock_fresh.last_inspected.is_some());
+
+        state.reconciler().mark_stale().await;
+        let aged = state.operator_status().await;
+        let mock_aged = aged
+            .runtimes
+            .iter()
+            .find(|r| r.runtime_id == "mock")
+            .expect("mock runtime");
+        assert_eq!(mock_aged.freshness, "stale");
+    }
+
+    #[tokio::test]
+    async fn status_summary_includes_residency_group_health() {
+        let state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+        state.run_reconciliation_tick().await;
+
+        let status = state.operator_status().await;
+        assert_eq!(status.residency_groups.len(), 2);
+
+        let small = status
+            .residency_groups
+            .iter()
+            .find(|g| g.group_id == "small_swarm")
+            .expect("small_swarm group");
+        assert!(small.keep_hot);
+        // qwen9b is hot_gpu in the mock runtime and belongs to small_swarm.
+        assert!(small.hot_resident_count >= 1);
+        assert_eq!(small.health, "healthy");
+
+        let large = status
+            .residency_groups
+            .iter()
+            .find(|g| g.group_id == "large_models")
+            .expect("large_models group");
+        assert!(!large.keep_hot);
+        assert_eq!(large.hot_resident_count, 0);
+        // Not keep-hot, so zero hot residents is still healthy.
+        assert_eq!(large.health, "healthy");
+    }
+
+    #[tokio::test]
+    async fn status_summary_includes_recent_decision_count() {
+        let state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+
+        let before = state.operator_status().await;
+        assert_eq!(before.recent_decision_count, 0);
+
+        state.decide(&sample_request()).await.expect("decision");
+
+        let after = state.operator_status().await;
+        assert_eq!(after.recent_decision_count, 1);
     }
 
     #[tokio::test]
@@ -1975,7 +2279,7 @@ pub fn openapi_document() -> serde_json::Value {
                             "description": "Configured control-plane counts",
                             "content": {
                                 "application/json": {
-                                    "schema": { "$ref": "#/components/schemas/StatusResponse" }
+                                    "schema": { "$ref": "#/components/schemas/OperatorStatus" }
                                 }
                             }
                         }
@@ -2104,14 +2408,27 @@ pub fn openapi_document() -> serde_json::Value {
                     "required": ["ok"],
                     "properties": { "ok": { "type": "boolean" } }
                 },
-                "StatusResponse": {
+                "OperatorStatus": {
                     "type": "object",
-                    "required": ["domains", "models", "runtimes", "residency_groups"],
+                    "required": [
+                        "cache_populated",
+                        "runtimes",
+                        "residency_groups",
+                        "active_request_count",
+                        "staging",
+                        "recent_decision_count",
+                        "policy_warnings",
+                        "live_execution_enabled"
+                    ],
                     "properties": {
-                        "domains": { "type": "integer" },
-                        "models": { "type": "integer" },
-                        "runtimes": { "type": "integer" },
-                        "residency_groups": { "type": "integer" }
+                        "cache_populated": { "type": "boolean" },
+                        "runtimes": { "type": "array", "items": { "type": "object" } },
+                        "residency_groups": { "type": "array", "items": { "type": "object" } },
+                        "active_request_count": { "type": "integer" },
+                        "staging": { "type": "object" },
+                        "recent_decision_count": { "type": "integer" },
+                        "policy_warnings": { "type": "array", "items": { "type": "string" } },
+                        "live_execution_enabled": { "type": "boolean" }
                     }
                 },
                 "InferenceRequest": {
@@ -2188,21 +2505,8 @@ pub fn openapi_document() -> serde_json::Value {
     })
 }
 
-#[derive(Serialize)]
-struct StatusResponse {
-    domains: usize,
-    models: usize,
-    runtimes: usize,
-    residency_groups: usize,
-}
-
-async fn status(State(state): State<AppState>) -> Json<StatusResponse> {
-    Json(StatusResponse {
-        domains: state.config.domains.len(),
-        models: state.config.models.len(),
-        runtimes: state.config.runtimes.len(),
-        residency_groups: state.config.residency_groups.len(),
-    })
+async fn status(State(state): State<AppState>) -> Json<OperatorStatus> {
+    Json(state.operator_status().await)
 }
 
 async fn residents(State(state): State<AppState>) -> Json<Vec<RuntimeSnapshot>> {

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -46,7 +46,7 @@ hardening when the local toolchain has the `clippy` component installed.
 | 23 load/unload action plan | Decisions produce explicit dry-run action plans before runtime mutation. | `anemoi-core`, `anemoi-daemon`, `anemoi-runtime` | Passing |
 | 24 resource pressure model | Candidate scoring uses explicit VRAM, RAM, KV, load, and active-request pressure evidence. | `anemoi-policy`, `anemoi-core` | Passing |
 | 25 eviction and pinning policy | Keep-hot workers are protected and eviction plans are explainable and gated. | `anemoi-policy`, `anemoi-core`, `anemoi-runtime` | Passing |
-| 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Pending |
+| 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Passing |
 | 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Pending |
 | 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Pending |
 


### PR DESCRIPTION
## Summary
- Replace the config-count `/status` response with an `OperatorStatus` view built purely from the reconciled snapshot cache, config, staging queue, and decision log — no live inspection.
- Surface runtime availability + freshness, residents by runtime, residency-group health, active requests, staging summary, recent decision count, policy warnings, and the live-execution gate state.
- Label unknown and stale state explicitly (never silently omitted): un-inspected runtimes are `unknown`; aged/forced-stale snapshots are `stale`; unknown idle time is shown plainly.
- Render the same view as a human-readable table via `anemoi status`.
- Honor forced staleness in the reconciler cache (`mark_stale` / error records now surface as stale through `all()`/`get()`).

Folds #17 (consolidated diagnostics / route visibility).

## Required tests (all passing in `cargo test --workspace`)
- `status_summary_includes_runtime_availability_and_staleness`
- `status_summary_includes_residency_group_health`
- `status_summary_includes_recent_decision_count`
- `cli_status_prints_residents_staging_and_policy_summary`
- `cli_status_marks_unknown_and_stale_state_plainly`

Roadmap row 26 (operator status surface) flipped Pending → Passing in the same change.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)