### PR TITLE
chore: add anemoi-guard test-quality safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,5 @@ jobs:
         run: cargo test --workspace
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Guard (test-quality lint)
+        run: cargo run -p anemoi-guard -- crates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,43 @@ Required early coverage:
 Core policy tests should be single-purpose: one rule, one behavior, one reason
 to fail.
 
+### Tests Must Observe Behavior
+
+Green `fmt`, `test`, and `clippy` measure shape, not behavior. A change can pass
+all three and still deliver nothing. These rules close that gap and are the
+definition of done for any prompt that claims a working feature.
+
+- **Assert the observed value, not that a call returned.** `assert!(x.is_ok())`
+  or `assert!(x.is_some())` as the only assertion is not a passing test — it
+  cannot tell a working implementation from a broken one. Record something, read
+  it back, and `assert_eq!` the value you expected. Negative assertions
+  (`is_err`, `is_none`) are allowed when refusal or absence *is* the behavior
+  under test (for example, a safety gate that must deny).
+- **Durability requires a restart round-trip.** A claim that data survives
+  restart is proven only by writing through one store instance, dropping it, and
+  opening a *fresh* instance over the same file or URL to read the value back. A
+  test that reads from an in-memory cache held by the same instance proves
+  nothing about durability.
+- **The feature must be reachable from the real binary.** If the only caller of
+  a new code path is a `#[cfg(test)]` helper, the feature does not exist for
+  operators. Wire it into the daemon or CLI entry point and prove it through that
+  entry point. Production code never lives behind a public test-only function.
+- **External issue schemas are checklists.** When a prompt references an issue
+  that defines a schema (for example issue #12 `resident_events`), every required
+  column or field must exist and be exercised by a test that reads it back. A
+  schema that is documented but not populated and queried is incomplete.
+- **Grade before landing.** Before flipping a roadmap row to `Passing`, re-read
+  the acceptance criteria and confirm each one is met by a behavioral test, not
+  by the gates being green. If you cannot point to the test that would fail if
+  the feature regressed, the feature is not done.
+
+`anemoi-guard` (run in CI) enforces the mechanically checkable subset of the
+above: no `pub fn` inside a `#[cfg(test)]` module, and no test whose only
+assertion is `is_ok`/`is_some`. Suppress a genuinely intentional exception with a
+comment containing `anemoi-guard:allow` and a one-line reason. Reaching for the
+escape hatch instead of asserting a value is a code smell — prefer the real
+assertion.
+
 ---
 
 ## 12. Validation Expectations
@@ -232,6 +269,7 @@ For Rust changes, run the strongest applicable checks:
 cargo fmt --check
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
+cargo run -p anemoi-guard -- crates
 ```
 
 If Rust tooling is unavailable, report that explicitly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anemoi-guard"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
 name = "anemoi-mcp"
 version = "0.1.0"
 dependencies = [
@@ -1235,6 +1244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1941,15 @@ checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/anemoi-telemetry",
     "crates/anemoi-cli",
     "crates/anemoi-mcp",
+    "crates/anemoi-guard",
 ]
 
 [workspace.package]
@@ -33,7 +34,10 @@ reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+proc-macro2 = { version = "1", features = ["span-locations"] }
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 thiserror = "1"
+walkdir = "2"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "time"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.5", features = ["trace"] }

--- a/crates/anemoi-cli/src/main.rs
+++ b/crates/anemoi-cli/src/main.rs
@@ -283,6 +283,7 @@ fn format_decision(decision: &anemoi_core::Decision) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anemoi_core::ModelId;
     use anemoi_telemetry::InMemoryDecisionLog;
     use std::sync::Arc;
 
@@ -430,7 +431,7 @@ mod tests {
 
         let decision = state.decide(&request).await.expect("decision");
 
-        assert!(decision.selected_model.is_some());
+        assert_eq!(decision.selected_model, Some(ModelId("qwen9b".to_string())));
     }
 
     async fn run_cli<const N: usize>(args: [&str; N]) -> String {

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -960,6 +960,8 @@ mod tests {
     use std::collections::HashMap;
     use tower::ServiceExt;
 
+    // anemoi-guard:allow vacuous-test - construction smoke test; richer
+    // no-database behavior is covered by cli_decide_works_without_database_url
     #[test]
     fn daemon_starts_without_database_url() {
         let config = example_config();
@@ -1680,10 +1682,13 @@ mod tests {
             .expect("execute should succeed");
 
         let intents = staging_worker.get_all().await;
-        let completed = intents.iter().find(|i| i.state == StagingState::Completed);
-        assert!(
-            completed.is_some(),
-            "staging should complete on mock runtime"
+        let completed = intents
+            .iter()
+            .find(|i| i.state == StagingState::Completed)
+            .expect("staging should complete on mock runtime");
+        assert_eq!(
+            completed.background_model,
+            ModelId("qwen35_a3b".to_string())
         );
     }
 
@@ -1792,10 +1797,11 @@ mod tests {
 
         let plan = state.generate_action_plan(&decision, true);
 
-        assert!(
-            plan.get_foreground_load().is_some(),
-            "action plan should contain foreground load for cold load decision"
-        );
+        let load = plan
+            .get_foreground_load()
+            .expect("action plan should contain foreground load for cold load decision");
+        assert_eq!(load.model_id, Some(ModelId("qwen35_a3b".to_string())));
+        assert_eq!(load.runtime_id, RuntimeId("mock".to_string()));
     }
 
     #[tokio::test]
@@ -1822,10 +1828,11 @@ mod tests {
 
         let plan = state.generate_action_plan(&decision, true);
 
-        assert!(
-            plan.get_background_load().is_some(),
-            "action plan should contain background load for stage background decision"
-        );
+        let load = plan
+            .get_background_load()
+            .expect("action plan should contain background load for stage background decision");
+        assert_eq!(load.model_id, Some(ModelId("qwen35_a3b".to_string())));
+        assert!(!load.is_foreground);
     }
 
     #[tokio::test]

--- a/crates/anemoi-guard/Cargo.toml
+++ b/crates/anemoi-guard/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anemoi-guard"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "anemoi-guard"
+path = "src/main.rs"
+
+[dependencies]
+proc-macro2.workspace = true
+syn.workspace = true
+walkdir.workspace = true

--- a/crates/anemoi-guard/src/lib.rs
+++ b/crates/anemoi-guard/src/lib.rs
@@ -1,0 +1,390 @@
+//! Static checks that catch tests which look green but verify nothing, and
+//! production code that hides inside test-only modules.
+//!
+//! These two patterns were the root cause of a durable-event-store change that
+//! passed `cargo test`, `fmt`, and `clippy` while delivering no working
+//! feature: the only code path that read `ANEMOI_DATABASE_URL` lived in a
+//! `pub fn` inside a `#[cfg(test)]` module (so the real binary never reached
+//! it), and the tests asserted only `result.is_ok()` (so they could not tell a
+//! working store from a broken one).
+//!
+//! A check fires unless the offending function carries an escape-hatch comment
+//! containing `anemoi-guard:allow` somewhere within its span.
+
+use syn::spanned::Spanned;
+use syn::visit::Visit;
+use syn::{Attribute, Item, Macro, Visibility};
+
+const ALLOW_MARKER: &str = "anemoi-guard:allow";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rule {
+    /// A `pub`/`pub(...)` function declared inside a `#[cfg(test)]` module.
+    /// Real tests never need to be public; visibility here is a tell that
+    /// production logic is hiding where the shipped binary cannot reach it.
+    PubFnInTestModule,
+    /// A test whose only assertions are `is_ok`/`is_some` with no value
+    /// comparison — it proves a call succeeded or produced *something*, not
+    /// *what* it produced, so it cannot distinguish a working implementation
+    /// from a broken one. Negative assertions (`is_err`/`is_none`) are left
+    /// alone: asserting a refusal or an absence is a deliberate behavioral
+    /// claim, not a missing value check.
+    VacuousTest,
+}
+
+impl Rule {
+    pub fn code(self) -> &'static str {
+        match self {
+            Rule::PubFnInTestModule => "pub-fn-in-test-module",
+            Rule::VacuousTest => "vacuous-test",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub rule: Rule,
+    pub item: String,
+    pub line: usize,
+    pub message: String,
+}
+
+/// Parse `source` and return every violation found. The `Err` case is reserved
+/// for source that does not parse as Rust; callers should surface it rather
+/// than treat unparseable input as clean.
+pub fn analyze_source(source: &str) -> Result<Vec<Violation>, syn::Error> {
+    let file = syn::parse_file(source)?;
+    let lines: Vec<&str> = source.lines().collect();
+    let mut violations = Vec::new();
+    check_items(&file.items, false, &lines, &mut violations);
+    Ok(violations)
+}
+
+/// A function is suppressed when an `anemoi-guard:allow` marker appears within
+/// its token span, or in the contiguous block of comments/attributes directly
+/// above it (the natural place to write the marker).
+fn is_allowed(lines: &[&str], start: usize, end: usize) -> bool {
+    if (start..=end).any(|line| line_contains_marker(lines, line)) {
+        return true;
+    }
+    let mut line = start;
+    while line > 1 {
+        line -= 1;
+        let text = lines.get(line - 1).map(|t| t.trim()).unwrap_or("");
+        let is_decorator = text.is_empty()
+            || text.starts_with("//")
+            || text.starts_with("#[")
+            || text.starts_with("#!");
+        if !is_decorator {
+            break;
+        }
+        if line_contains_marker(lines, line) {
+            return true;
+        }
+    }
+    false
+}
+
+fn line_contains_marker(lines: &[&str], line: usize) -> bool {
+    lines
+        .get(line - 1)
+        .is_some_and(|text| text.contains(ALLOW_MARKER))
+}
+
+fn check_items(items: &[Item], in_test_module: bool, lines: &[&str], out: &mut Vec<Violation>) {
+    for item in items {
+        match item {
+            Item::Mod(module) => {
+                let nested_test = in_test_module || has_cfg_test(&module.attrs);
+                if let Some((_, inner)) = &module.content {
+                    check_items(inner, nested_test, lines, out);
+                }
+            }
+            Item::Fn(func) => {
+                let span = func.span();
+                let (start, end) = (span.start().line, span.end().line);
+                let allowed = is_allowed(lines, start, end);
+
+                if in_test_module && !allowed && !matches!(func.vis, Visibility::Inherited) {
+                    out.push(Violation {
+                        rule: Rule::PubFnInTestModule,
+                        item: func.sig.ident.to_string(),
+                        line: start,
+                        message: format!(
+                            "`{}` is public inside a #[cfg(test)] module; production code reached \
+                             only from tests is unreachable from the binary",
+                            func.sig.ident
+                        ),
+                    });
+                }
+
+                if has_test_attr(&func.attrs) && !allowed && is_vacuous(func) {
+                    out.push(Violation {
+                        rule: Rule::VacuousTest,
+                        item: func.sig.ident.to_string(),
+                        line: start,
+                        message: format!(
+                            "test `{}` only asserts is_ok/is_some; assert the observed value, \
+                             not just that a call succeeded or produced something",
+                            func.sig.ident
+                        ),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn has_cfg_test(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && matches!(&attr.meta, syn::Meta::List(list) if list.tokens.to_string().contains("test"))
+    })
+}
+
+fn has_test_attr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "test")
+    })
+}
+
+fn is_vacuous(func: &syn::ItemFn) -> bool {
+    let mut scan = AssertScan::default();
+    scan.visit_block(&func.block);
+    scan.weak >= 1 && scan.strong == 0
+}
+
+#[derive(Default)]
+struct AssertScan {
+    weak: usize,
+    strong: usize,
+}
+
+impl<'ast> Visit<'ast> for AssertScan {
+    fn visit_macro(&mut self, mac: &'ast Macro) {
+        let name = mac
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+            .unwrap_or_default();
+        match name.as_str() {
+            "assert_eq" | "assert_ne" | "assert_matches" | "debug_assert_eq"
+            | "debug_assert_ne" => self.strong += 1,
+            "assert" | "debug_assert" => {
+                if is_weak_condition(&mac.tokens.to_string()) {
+                    self.weak += 1;
+                } else {
+                    self.strong += 1;
+                }
+            }
+            _ => {}
+        }
+        syn::visit::visit_macro(self, mac);
+    }
+}
+
+fn is_weak_condition(tokens: &str) -> bool {
+    let probes = ["is_ok", "is_some"];
+    let has_probe = probes.iter().any(|probe| tokens.contains(probe));
+    let has_comparison = tokens.contains("==") || tokens.contains("!=");
+    has_probe && !has_comparison
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rules(source: &str) -> Vec<Rule> {
+        analyze_source(source)
+            .expect("source parses")
+            .into_iter()
+            .map(|violation| violation.rule)
+            .collect()
+    }
+
+    #[test]
+    fn flags_pub_fn_inside_cfg_test_module() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                pub fn create_decision_log() -> u32 { 1 }
+            }
+        "#;
+
+        let found = analyze_source(source).expect("parses");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].rule, Rule::PubFnInTestModule);
+        assert_eq!(found[0].item, "create_decision_log");
+    }
+
+    #[test]
+    fn ignores_private_fn_inside_cfg_test_module() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                fn helper() -> u32 { 1 }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn ignores_pub_fn_outside_test_module() {
+        let source = "pub fn record_decision() -> u32 { 1 }";
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn flags_test_that_only_checks_is_ok() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn stores_decision() {
+                    let result = save();
+                    assert!(result.is_ok());
+                }
+            }
+        "#;
+
+        let found = analyze_source(source).expect("parses");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].rule, Rule::VacuousTest);
+        assert_eq!(found[0].item, "stores_decision");
+    }
+
+    #[test]
+    fn flags_test_that_only_checks_is_some() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[tokio::test]
+                async fn finds_record() {
+                    assert!(lookup().is_some());
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), vec![Rule::VacuousTest]);
+    }
+
+    #[test]
+    fn accepts_test_whose_only_assertion_is_a_refusal() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[tokio::test]
+                async fn live_execution_requires_flag() {
+                    assert!(execute().await.is_err(), "should refuse without flag");
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn accepts_test_whose_only_assertion_is_an_absence() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn nothing_resident_yet() {
+                    assert!(snapshot.last_inspected.is_none());
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn accepts_test_that_compares_a_value() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn reads_back_what_was_written() {
+                    let got = store.get(id);
+                    assert_eq!(got, Some(expected));
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn accepts_weak_probe_when_a_strong_assert_is_present() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn records_and_reads_back() {
+                    let stored = store.record(&decision);
+                    assert!(stored.is_ok());
+                    assert_eq!(store.get(decision.id), Some(decision));
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn accepts_assert_with_explicit_comparison_even_using_a_probe_value() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                #[test]
+                fn count_is_one() {
+                    assert!(rows.len() == 1 && first.is_some());
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn allow_marker_suppresses_vacuous_test() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                // anemoi-guard:allow vacuous-test - intentional smoke test
+                #[test]
+                fn boots() {
+                    assert!(start().is_ok());
+                }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn allow_marker_suppresses_pub_fn_in_test_module() {
+        let source = r#"
+            #[cfg(test)]
+            mod tests {
+                // anemoi-guard:allow pub-fn-in-test-module
+                pub fn fixture() -> u32 { 1 }
+            }
+        "#;
+
+        assert_eq!(rules(source), Vec::<Rule>::new());
+    }
+
+    #[test]
+    fn reports_unparseable_source_as_error() {
+        let result = analyze_source("fn broken( {");
+        assert!(result.is_err());
+    }
+}

--- a/crates/anemoi-guard/src/main.rs
+++ b/crates/anemoi-guard/src/main.rs
@@ -1,0 +1,67 @@
+//! Walks Rust sources under the given root (default: current directory) and
+//! reports anemoi-guard violations. Exits non-zero when any are found so CI
+//! fails the build.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use anemoi_guard::analyze_source;
+use walkdir::WalkDir;
+
+fn main() -> ExitCode {
+    let root = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    let mut total = 0usize;
+    let mut scanned = 0usize;
+
+    for entry in WalkDir::new(&root)
+        .into_iter()
+        .filter_entry(|entry| entry.file_name() != "target")
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+
+        let source = match std::fs::read_to_string(path) {
+            Ok(source) => source,
+            Err(err) => {
+                eprintln!("anemoi-guard: cannot read {}: {err}", path.display());
+                return ExitCode::FAILURE;
+            }
+        };
+
+        scanned += 1;
+        match analyze_source(&source) {
+            Ok(violations) => {
+                for violation in &violations {
+                    total += 1;
+                    report(path, violation);
+                }
+            }
+            Err(err) => {
+                eprintln!("anemoi-guard: cannot parse {}: {err}", path.display());
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    if total == 0 {
+        println!("anemoi-guard: {scanned} files scanned, no violations");
+        ExitCode::SUCCESS
+    } else {
+        eprintln!("anemoi-guard: {total} violation(s) across {scanned} files");
+        eprintln!("suppress an intentional case with a comment containing `anemoi-guard:allow`");
+        ExitCode::FAILURE
+    }
+}
+
+fn report(path: &Path, violation: &anemoi_guard::Violation) {
+    eprintln!(
+        "{}:{} [{}] {}",
+        path.display(),
+        violation.line,
+        violation.rule.code(),
+        violation.message
+    );
+}

--- a/crates/anemoi-mcp/src/lib.rs
+++ b/crates/anemoi-mcp/src/lib.rs
@@ -131,10 +131,9 @@ mod tests {
         let decision = service.decide(sample_request()).await.expect("decision");
         let json = serde_json::to_value(&decision).expect("decision json");
 
-        assert!(json.get("action").is_some());
-        assert!(json.get("selected_model").is_some());
-        assert!(json.get("score").is_some());
-        assert!(json.get("explanation").is_some());
+        let roundtrip: anemoi_core::Decision =
+            serde_json::from_value(json).expect("decision deserializes from its json shape");
+        assert_eq!(roundtrip, decision);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Encodes safeguards against the class of defect found while grading the durable
event store work (#33): a change that passed `fmt`/`test`/`clippy` while
delivering no working feature, because the only code path reading
`ANEMOI_DATABASE_URL` lived in a `pub fn` inside a `#[cfg(test)]` module and the
tests asserted only `is_ok`.

Two layers:

- **`anemoi-guard`** — a new `syn`-based workspace member that flags `pub fn`
  inside `#[cfg(test)]` modules and tests whose only assertion is `is_ok`/`is_some`.
  Negative assertions (`is_err`/`is_none`) are deliberate and left alone. An
  `anemoi-guard:allow` comment suppresses an intentional exception. Wired into CI.
- **AGENTS.md test-honesty contract** — the definition of done for feature
  prompts: assert observed values, prove durability with a restart round-trip,
  keep features reachable from the real binary, treat referenced issue schemas as
  checklists, and grade before landing.

Five pre-existing tests that the guard flagged were strengthened to assert real
values; one genuine construction smoke test carries an allow marker.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` (incl. 13 new anemoi-guard tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p anemoi-guard -- crates` reports no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)