### PR TITLE
fix(telemetry): make durable event store genuinely durable (Closes #33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +129,10 @@ dependencies = [
  "anemoi-core",
  "async-trait",
  "chrono",
+ "futures",
+ "parking_lot",
+ "rusqlite",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -420,6 +436,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,12 +496,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -481,6 +525,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -500,8 +572,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -551,6 +628,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -563,6 +649,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -887,6 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1003,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1033,6 +1148,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1230,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -1177,6 +1324,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1403,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1784,6 +1951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2361,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,11 @@ async-trait = "0.1"
 axum = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+futures = "0.3"
+parking_lot = "0.12"
 regex = "1"
 reqwest = { version = "0.12", features = ["json"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -953,7 +953,7 @@ mod tests {
         DecisionAction, DomainId, ExecutionMode, ModelId, ModelProfileConfig, ModelResident,
         RequestId, ResidencyState, RuntimeConfig, RuntimeId,
     };
-    use anemoi_telemetry::{DecisionLog, InMemoryDecisionLog};
+    use anemoi_telemetry::{decision_log_from, DecisionLog, InMemoryDecisionLog, SqliteEventStore};
     use axum::body::{to_bytes, Body};
     use axum::http::{Method, Request};
     use serde_json::Value;
@@ -971,70 +971,46 @@ mod tests {
         assert!(state.is_ok());
     }
 
-    #[test]
-    fn daemon_starts_with_memory_store_when_database_url_is_missing() {
-        // When ANEMOI_DATABASE_URL is not set (or empty), should use in-memory store.
-        let config = example_config();
+    #[tokio::test]
+    async fn daemon_starts_with_memory_store_when_database_url_is_missing() {
+        // With no database URL, the daemon wires an in-memory log: a decision it
+        // records is retrievable from that same log instance.
+        let log = decision_log_from(None, None).expect("memory log");
+        let state = AppState::new(example_config(), log.clone()).expect("state");
 
-        // Create the decision log without database URL
-        let log: DynDecisionLog = Arc::new(InMemoryDecisionLog::default());
-        let state = AppState::new(config, log);
-
-        assert!(
-            state.is_ok(),
-            "daemon should start with memory store when no database URL is set"
-        );
+        let decision = state.decide(&sample_request()).await.expect("decide");
+        let found = log
+            .get_decision(decision.id)
+            .await
+            .expect("get")
+            .expect("decision is recorded in the memory log");
+        assert_eq!(found, decision);
     }
 
-    #[test]
-    fn daemon_uses_sqlite_store_when_database_url_is_present() {
-        // When ANEMOI_DATABASE_URL is set, use SQLite.
-        let config = example_config();
-
-        // Create a temporary database for this test.
+    #[tokio::test]
+    async fn daemon_uses_sqlite_store_when_database_url_is_present() {
+        // A `sqlite://` URL routes the daemon through the same code path the
+        // real binary uses (default_decision_log -> decision_log_from), and a
+        // decision it records survives a process "restart" (reopen of the file).
         let temp_db_path = std::env::temp_dir().join(format!("anemoi-test-{}.db", Uuid::new_v4()));
+        let url = format!("sqlite:///{}", temp_db_path.display());
 
-        // Set the environment variable to use SQLite
-        std::env::set_var(
-            "ANEMOI_DATABASE_URL",
-            format!("sqlite:///{}", temp_db_path.display()),
-        );
+        let decision = {
+            let log = decision_log_from(Some(&url), None).expect("sqlite log");
+            let state = AppState::new(example_config(), log).expect("state");
+            state.decide(&sample_request()).await.expect("decide")
+        };
 
-        let log = create_decision_log();
-        let state = AppState::new(config, log);
+        // Reopen the SQLite file fresh: the decision is durable across restart.
+        let reopened = SqliteEventStore::create(&temp_db_path).expect("reopen sqlite store");
+        let found = reopened
+            .get_decision(decision.id)
+            .await
+            .expect("get")
+            .expect("decision is durable in the SQLite store");
+        assert_eq!(found, decision);
 
-        // Clean up
-        std::env::remove_var("ANEMOI_DATABASE_URL");
         let _ = std::fs::remove_file(&temp_db_path);
-
-        assert!(
-            state.is_ok(),
-            "daemon should use SQLite store when ANEMOI_DATABASE_URL is set"
-        );
-    }
-
-    /// Creates a decision log based on ANEMOI_DATABASE_URL environment variable.
-    /// When the env var is set (e.g. `sqlite:///path/to/db.db`), uses SQLite store.
-    /// Otherwise defaults to in-memory storage.
-    pub fn create_decision_log() -> DynDecisionLog {
-        if let Ok(db_url) = std::env::var("ANEMOI_DATABASE_URL") {
-            // Parse sqlite:// path format
-            if db_url.starts_with("sqlite:///") || db_url.starts_with("sqlite://") {
-                let path = &db_url["sqlite:///".len()..];
-                match anemoi_telemetry::SqliteEventStore::create(path) {
-                    Ok(store) => return Arc::new(store),
-                    Err(e) => eprintln!("Failed to create SQLite store: {}", e),
-                }
-            } else if let Some(path) = db_url.strip_prefix("sqlite:") {
-                // Handle other formats
-                match anemoi_telemetry::SqliteEventStore::create(path) {
-                    Ok(store) => return Arc::new(store),
-                    Err(e) => eprintln!("Failed to create SQLite store: {}", e),
-                }
-            }
-        }
-        // Fall back to in-memory
-        Arc::new(InMemoryDecisionLog::default())
     }
 
     #[tokio::test]

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -969,6 +969,72 @@ mod tests {
         assert!(state.is_ok());
     }
 
+    #[test]
+    fn daemon_starts_with_memory_store_when_database_url_is_missing() {
+        // When ANEMOI_DATABASE_URL is not set (or empty), should use in-memory store.
+        let config = example_config();
+
+        // Create the decision log without database URL
+        let log: DynDecisionLog = Arc::new(InMemoryDecisionLog::default());
+        let state = AppState::new(config, log);
+
+        assert!(
+            state.is_ok(),
+            "daemon should start with memory store when no database URL is set"
+        );
+    }
+
+    #[test]
+    fn daemon_uses_sqlite_store_when_database_url_is_present() {
+        // When ANEMOI_DATABASE_URL is set, use SQLite.
+        let config = example_config();
+
+        // Create a temporary database for this test.
+        let temp_db_path = std::env::temp_dir().join(format!("anemoi-test-{}.db", Uuid::new_v4()));
+
+        // Set the environment variable to use SQLite
+        std::env::set_var(
+            "ANEMOI_DATABASE_URL",
+            format!("sqlite:///{}", temp_db_path.display()),
+        );
+
+        let log = create_decision_log();
+        let state = AppState::new(config, log);
+
+        // Clean up
+        std::env::remove_var("ANEMOI_DATABASE_URL");
+        let _ = std::fs::remove_file(&temp_db_path);
+
+        assert!(
+            state.is_ok(),
+            "daemon should use SQLite store when ANEMOI_DATABASE_URL is set"
+        );
+    }
+
+    /// Creates a decision log based on ANEMOI_DATABASE_URL environment variable.
+    /// When the env var is set (e.g. `sqlite:///path/to/db.db`), uses SQLite store.
+    /// Otherwise defaults to in-memory storage.
+    pub fn create_decision_log() -> DynDecisionLog {
+        if let Ok(db_url) = std::env::var("ANEMOI_DATABASE_URL") {
+            // Parse sqlite:// path format
+            if db_url.starts_with("sqlite:///") || db_url.starts_with("sqlite://") {
+                let path = &db_url["sqlite:///".len()..];
+                match anemoi_telemetry::SqliteEventStore::create(path) {
+                    Ok(store) => return Arc::new(store),
+                    Err(e) => eprintln!("Failed to create SQLite store: {}", e),
+                }
+            } else if let Some(path) = db_url.strip_prefix("sqlite:") {
+                // Handle other formats
+                match anemoi_telemetry::SqliteEventStore::create(path) {
+                    Ok(store) => return Arc::new(store),
+                    Err(e) => eprintln!("Failed to create SQLite store: {}", e),
+                }
+            }
+        }
+        // Fall back to in-memory
+        Arc::new(InMemoryDecisionLog::default())
+    }
+
     #[tokio::test]
     async fn health_returns_ok() {
         let response = test_router()

--- a/crates/anemoi-telemetry/Cargo.toml
+++ b/crates/anemoi-telemetry/Cargo.toml
@@ -7,10 +7,14 @@ license.workspace = true
 [dependencies]
 anemoi-core.workspace = true
 async-trait.workspace = true
+chrono.workspace = true
+parking_lot.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-chrono.workspace = true
 tokio.workspace = true
+futures.workspace = true

--- a/crates/anemoi-telemetry/src/lib.rs
+++ b/crates/anemoi-telemetry/src/lib.rs
@@ -1,10 +1,14 @@
-use anemoi_core::Decision;
+use anemoi_core::{ActionPlan, Decision, RuntimeSnapshot};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Debug, thiserror::Error)]
@@ -13,6 +17,8 @@ pub enum TelemetryError {
     Io(#[from] std::io::Error),
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
 }
 
 #[async_trait]
@@ -23,6 +29,263 @@ pub trait DecisionLog: Send + Sync {
 }
 
 pub type DynDecisionLog = Arc<dyn DecisionLog>;
+
+/// Event record types for the durable event store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event_type")]
+pub enum StoredEvent {
+    #[serde(rename = "decision")]
+    Decision {
+        id: Uuid,
+        decision: Decision,
+        recorded_at: DateTime<Utc>,
+    },
+    #[serde(rename = "runtime_snapshot")]
+    RuntimeSnapshot {
+        id: Uuid,
+        runtime_id: String,
+        snapshot: RuntimeSnapshot,
+        observed_at: DateTime<Utc>,
+    },
+    #[serde(rename = "resident_transition")]
+    ResidentTransition {
+        id: Uuid,
+        model_id: String,
+        from_state: String,
+        to_state: String,
+        evidence_source: Option<String>,
+        decision_id: Option<Uuid>,
+        transition_recorded_at: DateTime<Utc>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredActionPlan {
+    pub decision_id: Uuid,
+    pub actions_json: String,
+}
+
+/// SQLite-backed event store for durable history.
+/// Uses a mutex to make the connection safe across async contexts.
+pub struct SqliteEventStore {
+    conn: Mutex<Connection>,
+    memory_log: InMemoryDecisionLog,
+}
+
+impl SqliteEventStore {
+    /// Creates a new SQLite database at the given path with initialized tables.
+    pub fn create(path: impl AsRef<Path>) -> Result<Self, TelemetryError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
+        let conn = Connection::open(path)?;
+
+        // Enable WAL mode for better concurrent read performance.
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+
+        let store = Self {
+            conn: Mutex::new(conn),
+            memory_log: InMemoryDecisionLog::default(),
+        };
+        store.init_tables()?;
+        Ok(store)
+    }
+
+    fn init_tables(&self) -> Result<(), TelemetryError> {
+        // Create tables using the connection directly.
+        let guard = self.conn.lock();
+        guard.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS decisions (
+                id TEXT PRIMARY KEY,
+                decision_json TEXT NOT NULL,
+                recorded_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS runtime_snapshots (
+                event_id TEXT NOT NULL,
+                runtime_id TEXT NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                observed_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS resident_transitions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                model_id TEXT NOT NULL,
+                from_state TEXT NOT NULL,
+                to_state TEXT NOT NULL,
+                evidence_source TEXT,
+                decision_id TEXT,
+                transition_recorded_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS staging_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                intent_id TEXT NOT NULL,
+                decision_id TEXT NOT NULL,
+                background_model TEXT NOT NULL,
+                target_runtime TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                state TEXT NOT NULL,
+                recorded_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS action_plan_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                decision_id TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                recorded_at TEXT NOT NULL
+            );
+            "#,
+        )?;
+        Ok(())
+    }
+
+    /// Records a runtime snapshot event.
+    pub fn record_runtime_snapshot(
+        &self,
+        id: Uuid,
+        runtime_id: &str,
+        snapshot: &RuntimeSnapshot,
+    ) -> Result<(), TelemetryError> {
+        let json = serde_json::to_string(snapshot)?;
+        let observed_at = Utc::now().to_rfc3339();
+        self.conn.lock().execute(
+            "INSERT INTO runtime_snapshots (event_id, runtime_id, snapshot_json, observed_at) VALUES (?1, ?2, ?3, ?4)",
+            params![id.to_string(), runtime_id, &json, &observed_at],
+        )?;
+        Ok(())
+    }
+
+    /// Records a resident transition event.
+    pub fn record_resident_transition(
+        &self,
+        model_id: &str,
+        from_state: &str,
+        to_state: &str,
+        evidence_source: Option<&str>,
+        decision_id: Option<Uuid>,
+    ) -> Result<(), TelemetryError> {
+        let recorded_at = Utc::now().to_rfc3339();
+        self.conn.lock().execute(
+            r#"INSERT INTO resident_transitions
+               (model_id, from_state, to_state, evidence_source, decision_id, transition_recorded_at)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+            params![
+                model_id,
+                from_state,
+                to_state,
+                evidence_source,
+                decision_id.map(|id| id.to_string()),
+                recorded_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Records a staging event.
+    pub fn record_staging_event(
+        &self,
+        intent_id: Uuid,
+        decision_id: Uuid,
+        background_model: &str,
+        target_runtime: &str,
+        reason: &str,
+        state: &str,
+    ) -> Result<(), TelemetryError> {
+        let recorded_at = Utc::now().to_rfc3339();
+        self.conn.lock().execute(
+            "INSERT INTO staging_events
+               (intent_id, decision_id, background_model, target_runtime, reason, state, recorded_at)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                intent_id.to_string(),
+                decision_id.to_string(),
+                background_model,
+                target_runtime,
+                reason,
+                state,
+                recorded_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Records an action plan event.
+    pub fn record_action_plan_event(&self, plan: &ActionPlan) -> Result<(), TelemetryError> {
+        let json = serde_json::to_string(plan)?;
+        let recorded_at = Utc::now().to_rfc3339();
+        self.conn.lock().execute(
+            "INSERT INTO action_plan_events (decision_id, plan_json, recorded_at) VALUES (?1, ?2, ?3)",
+            params![plan.decision_id.to_string(), &json, recorded_at],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieves a decision explanation by ID.
+    pub fn get_decision_explanation(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<anemoi_core::Explanation>, TelemetryError> {
+        let guard = self.conn.lock();
+        let mut stmt = guard.prepare("SELECT decision_json FROM decisions WHERE id = ?1")?;
+        let result: Option<String> = stmt
+            .query_row(params![id.to_string()], |row| row.get(0))
+            .ok();
+        match result {
+            Some(json_str) => {
+                drop(stmt);
+                drop(guard);
+                let decision: Decision = serde_json::from_str(&json_str)?;
+                Ok(Some(decision.explanation))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Records a decision to in-memory log.
+    pub async fn record_to_memory(&self, decision: &Decision) -> Result<(), TelemetryError> {
+        self.memory_log.record_decision(decision).await
+    }
+}
+
+impl Default for SqliteEventStore {
+    fn default() -> Self {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite");
+        let store = Self {
+            conn: Mutex::new(conn),
+            memory_log: InMemoryDecisionLog::default(),
+        };
+        store.init_tables().expect("init tables");
+        store
+    }
+}
+
+#[async_trait]
+impl DecisionLog for SqliteEventStore {
+    async fn record_decision(&self, decision: &Decision) -> Result<(), TelemetryError> {
+        // Also update in-memory log.
+        self.record_to_memory(decision).await?;
+
+        let id = decision.id.to_string();
+        let json = serde_json::to_string(decision)?;
+        let recorded_at = Utc::now().to_rfc3339();
+
+        self.conn.lock().execute(
+            "INSERT OR REPLACE INTO decisions (id, decision_json, recorded_at) VALUES (?1, ?2, ?3)",
+            params![&id, &json, &recorded_at],
+        )?;
+        Ok(())
+    }
+
+    async fn get_decision(&self, id: Uuid) -> Result<Option<Decision>, TelemetryError> {
+        self.memory_log.get_decision(id).await
+    }
+
+    async fn list_decisions(&self) -> Result<Vec<Decision>, TelemetryError> {
+        self.memory_log.list_decisions().await
+    }
+}
 
 pub fn default_decision_log(jsonl_path: Option<PathBuf>) -> Result<DynDecisionLog, TelemetryError> {
     jsonl_path
@@ -36,7 +299,13 @@ pub fn default_decision_log(jsonl_path: Option<PathBuf>) -> Result<DynDecisionLo
 
 #[derive(Debug, Default)]
 pub struct InMemoryDecisionLog {
-    state: RwLock<InMemoryDecisionLogState>,
+    state: std::sync::RwLock<InMemoryDecisionLogState>,
+}
+
+impl InMemoryDecisionLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -48,7 +317,7 @@ struct InMemoryDecisionLogState {
 #[async_trait]
 impl DecisionLog for InMemoryDecisionLog {
     async fn record_decision(&self, decision: &Decision) -> Result<(), TelemetryError> {
-        let mut state = self.state.write().expect("decision log lock");
+        let mut state = self.state.write().unwrap();
         if !state.decisions.contains_key(&decision.id) {
             state.order.push(decision.id);
         }
@@ -57,17 +326,12 @@ impl DecisionLog for InMemoryDecisionLog {
     }
 
     async fn get_decision(&self, id: Uuid) -> Result<Option<Decision>, TelemetryError> {
-        Ok(self
-            .state
-            .read()
-            .expect("decision log lock")
-            .decisions
-            .get(&id)
-            .cloned())
+        let state = self.state.read().unwrap();
+        Ok(state.decisions.get(&id).cloned())
     }
 
     async fn list_decisions(&self) -> Result<Vec<Decision>, TelemetryError> {
-        let state = self.state.read().expect("decision log lock");
+        let state = self.state.read().unwrap();
         Ok(state
             .order
             .iter()
@@ -85,10 +349,7 @@ pub struct JsonlDecisionLog {
 impl JsonlDecisionLog {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self, TelemetryError> {
         let path = path.into();
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
             std::fs::create_dir_all(parent)?;
         }
         Ok(Self {
@@ -106,7 +367,6 @@ impl JsonlDecisionLog {
 impl DecisionLog for JsonlDecisionLog {
     async fn record_decision(&self, decision: &Decision) -> Result<(), TelemetryError> {
         self.memory.record_decision(decision).await?;
-
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -128,156 +388,8 @@ impl DecisionLog for JsonlDecisionLog {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anemoi_core::{
-        Decision, DecisionAction, DecisionScore, Explanation, RejectedOption, RequestId,
-    };
-    use chrono::Utc;
-
-    #[tokio::test]
-    async fn memory_decision_log_stores_and_gets_decision() {
-        let log = InMemoryDecisionLog::default();
-        let decision = sample_decision();
-
-        log.record_decision(&decision).await.expect("record");
-
-        assert_eq!(
-            log.get_decision(decision.id).await.expect("get"),
-            Some(decision)
-        );
-    }
-
-    #[tokio::test]
-    async fn memory_decision_log_returns_none_for_unknown_decision() {
-        let log = InMemoryDecisionLog::default();
-
-        let found = log.get_decision(Uuid::new_v4()).await.expect("get");
-
-        assert_eq!(found, None);
-    }
-
-    #[tokio::test]
-    async fn memory_decision_log_keeps_recent_decisions_in_insert_order() {
-        let log = InMemoryDecisionLog::default();
-        let first = sample_decision_with_summary("first");
-        let second = sample_decision_with_summary("second");
-
-        log.record_decision(&second).await.expect("record second");
-        log.record_decision(&first).await.expect("record first");
-
-        assert_eq!(
-            log.list_decisions()
-                .await
-                .expect("list")
-                .into_iter()
-                .map(|decision| decision.explanation.summary)
-                .collect::<Vec<_>>(),
-            vec!["second", "first"]
-        );
-    }
-
-    #[tokio::test]
-    async fn jsonl_decision_log_appends_one_json_object_per_decision() {
-        let path = temp_jsonl_path();
-        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
-        let first = sample_decision_with_summary("first");
-        let second = sample_decision_with_summary("second");
-
-        log.record_decision(&first).await.expect("record first");
-        log.record_decision(&second).await.expect("record second");
-
-        let text = std::fs::read_to_string(&path).expect("jsonl file");
-        let lines = text.lines().collect::<Vec<_>>();
-        assert_eq!(lines.len(), 2);
-        assert_eq!(
-            serde_json::from_str::<Decision>(lines[0]).expect("first json"),
-            first
-        );
-        assert_eq!(
-            serde_json::from_str::<Decision>(lines[1]).expect("second json"),
-            second
-        );
-
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[tokio::test]
-    async fn jsonl_decision_log_creates_parent_directory_when_needed() {
-        let dir = std::env::temp_dir().join(format!("anemoi-{}", Uuid::new_v4()));
-        let path = dir.join("nested").join("decisions.jsonl");
-
-        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
-        log.record_decision(&sample_decision())
-            .await
-            .expect("record");
-
-        assert!(path.exists());
-
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[tokio::test]
-    async fn jsonl_decision_log_does_not_require_sqlite() {
-        let log = default_decision_log(None).expect("memory log");
-        let decision = sample_decision();
-
-        log.record_decision(&decision).await.expect("record");
-
-        assert_eq!(
-            log.get_decision(decision.id).await.expect("get"),
-            Some(decision)
-        );
-    }
-
-    #[tokio::test]
-    async fn telemetry_trait_supports_memory_and_jsonl_logs() {
-        let memory: DynDecisionLog = Arc::new(InMemoryDecisionLog::default());
-        let jsonl_path = temp_jsonl_path();
-        let jsonl: DynDecisionLog = Arc::new(JsonlDecisionLog::new(&jsonl_path).expect("jsonl"));
-
-        for log in [memory, jsonl] {
-            let decision = sample_decision();
-            log.record_decision(&decision).await.expect("record");
-            assert_eq!(
-                log.get_decision(decision.id).await.expect("get"),
-                Some(decision)
-            );
-        }
-
-        let _ = std::fs::remove_file(jsonl_path);
-    }
-
-    #[tokio::test]
-    async fn decision_log_defaults_to_memory() {
-        let log = default_decision_log(None).expect("default log");
-        let decision = sample_decision();
-
-        log.record_decision(&decision)
-            .await
-            .expect("record decision");
-
-        let found = log
-            .get_decision(decision.id)
-            .await
-            .expect("get decision")
-            .expect("decision exists");
-        assert_eq!(found.id, decision.id);
-    }
-
-    #[tokio::test]
-    async fn jsonl_decision_log_appends_decisions() {
-        let path = std::env::temp_dir().join(format!("anemoi-{}.jsonl", Uuid::new_v4()));
-        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
-        let decision = sample_decision();
-
-        log.record_decision(&decision)
-            .await
-            .expect("record decision");
-
-        let text = std::fs::read_to_string(&path).expect("jsonl file");
-        assert!(text.contains(&decision.id.to_string()));
-
-        let _ = std::fs::remove_file(path);
-    }
+    use anemoi_core::{DecisionAction, DecisionScore, Explanation, RejectedOption, RequestId};
+    use std::sync::Arc;
 
     fn sample_decision() -> Decision {
         sample_decision_with_summary("No runnable model candidate was available.")
@@ -304,5 +416,262 @@ mod tests {
 
     fn temp_jsonl_path() -> PathBuf {
         std::env::temp_dir().join(format!("anemoi-{}.jsonl", Uuid::new_v4()))
+    }
+
+    #[tokio::test]
+    async fn memory_decision_log_stores_and_gets_decision() {
+        let log = InMemoryDecisionLog::default();
+        let decision = sample_decision();
+        log.record_decision(&decision).await.expect("record");
+        assert_eq!(
+            log.get_decision(decision.id).await.expect("get"),
+            Some(decision)
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_decision_log_returns_none_for_unknown_decision() {
+        let log = InMemoryDecisionLog::default();
+        let found = log.get_decision(Uuid::new_v4()).await.expect("get");
+        assert_eq!(found, None);
+    }
+
+    #[tokio::test]
+    async fn memory_decision_log_keeps_recent_decisions_in_insert_order() {
+        let log = InMemoryDecisionLog::default();
+        let first = sample_decision_with_summary("first");
+        let second = sample_decision_with_summary("second");
+        log.record_decision(&second).await.expect("record second");
+        log.record_decision(&first).await.expect("record first");
+        assert_eq!(
+            log.list_decisions()
+                .await
+                .expect("list")
+                .into_iter()
+                .map(|d| d.explanation.summary)
+                .collect::<Vec<_>>(),
+            vec!["second", "first"]
+        );
+    }
+
+    #[tokio::test]
+    async fn jsonl_decision_log_appends_one_json_object_per_decision() {
+        let path = temp_jsonl_path();
+        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
+        let first = sample_decision_with_summary("first");
+        let second = sample_decision_with_summary("second");
+        log.record_decision(&first).await.expect("record first");
+        log.record_decision(&second).await.expect("record second");
+        let text = std::fs::read_to_string(&path).expect("jsonl file");
+        let lines: Vec<_> = text.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            serde_json::from_str::<Decision>(lines[0]).expect("first json"),
+            first
+        );
+        assert_eq!(
+            serde_json::from_str::<Decision>(lines[1]).expect("second json"),
+            second
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn jsonl_decision_log_creates_parent_directory_when_needed() {
+        let dir = std::env::temp_dir().join(format!("anemoi-{}", Uuid::new_v4()));
+        let path = dir.join("nested").join("decisions.jsonl");
+        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
+        log.record_decision(&sample_decision())
+            .await
+            .expect("record");
+        assert!(path.exists());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn jsonl_decision_log_does_not_require_sqlite() {
+        let log = default_decision_log(None).expect("memory log");
+        let decision = sample_decision();
+        log.record_decision(&decision).await.expect("record");
+        assert_eq!(
+            log.get_decision(decision.id).await.expect("get"),
+            Some(decision)
+        );
+    }
+
+    #[tokio::test]
+    async fn telemetry_trait_supports_memory_and_jsonl_logs() {
+        let memory: DynDecisionLog = Arc::new(InMemoryDecisionLog::default());
+        let jsonl_path = temp_jsonl_path();
+        let jsonl: DynDecisionLog = Arc::new(JsonlDecisionLog::new(&jsonl_path).expect("jsonl"));
+        for log in [memory, jsonl] {
+            let decision = sample_decision();
+            log.record_decision(&decision).await.expect("record");
+            assert_eq!(
+                log.get_decision(decision.id).await.expect("get"),
+                Some(decision)
+            );
+        }
+        let _ = std::fs::remove_file(jsonl_path);
+    }
+
+    #[tokio::test]
+    async fn decision_log_defaults_to_memory() {
+        let log = default_decision_log(None).expect("default log");
+        let decision = sample_decision();
+        log.record_decision(&decision)
+            .await
+            .expect("record decision");
+        let found = log
+            .get_decision(decision.id)
+            .await
+            .expect("get decision")
+            .expect("exists");
+        assert_eq!(found.id, decision.id);
+    }
+
+    #[tokio::test]
+    async fn jsonl_decision_log_appends_decisions() {
+        let path = std::env::temp_dir().join(format!("anemoi-{}.jsonl", Uuid::new_v4()));
+        let log = JsonlDecisionLog::new(&path).expect("jsonl log");
+        let decision = sample_decision();
+        log.record_decision(&decision)
+            .await
+            .expect("record decision");
+        let text = std::fs::read_to_string(&path).expect("jsonl file");
+        assert!(text.contains(&decision.id.to_string()));
+        let _ = std::fs::remove_file(path);
+    }
+
+    // =======================================================================
+    // SQLite Event Store Tests (Prompt 27)
+    // =======================================================================
+
+    fn temp_db_path() -> PathBuf {
+        std::env::temp_dir().join(format!("anemoi-{}.db", Uuid::new_v4()))
+    }
+
+    #[test]
+    fn sqlite_event_store_records_decision_event() {
+        let db_path = temp_db_path();
+        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+
+        // Record the decision
+        futures::executor::block_on(Arc::new(store).record_decision(&sample_decision()))
+            .expect("record");
+
+        // Verify by retrieving from a new store instance
+        let stored_store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let explanation = stored_store.get_decision_explanation(sample_decision().id);
+        assert!(explanation.is_ok());
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn sqlite_event_store_records_runtime_snapshot_event() {
+        let db_path = temp_db_path();
+        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let snapshot = RuntimeSnapshot {
+            runtime_id: anemoi_core::RuntimeId("mock".to_string()),
+            available: true,
+            residents: Vec::new(),
+            configured_models: vec![],
+            memory: anemoi_core::RuntimeMemorySnapshot::default(),
+            active_requests: Vec::new(),
+        };
+        let event_id = Uuid::new_v4();
+        store
+            .record_runtime_snapshot(event_id, "mock", &snapshot)
+            .expect("record snapshot");
+
+        // Verify by checking the database directly.
+        let conn = rusqlite::Connection::open(&db_path).expect("conn");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM runtime_snapshots WHERE event_id = ?1",
+                params![event_id.to_string()],
+                |row| row.get(0),
+            )
+            .expect("count query");
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn sqlite_event_store_records_staging_event() {
+        let db_path = temp_db_path();
+        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let decision_id = Uuid::new_v4();
+        let intent_id = Uuid::new_v4();
+
+        store
+            .record_staging_event(
+                intent_id,
+                decision_id,
+                "qwen35_a3b",
+                "mock",
+                "background staging test",
+                "pending",
+            )
+            .expect("record staging");
+
+        // Verify by checking the database directly.
+        let conn = rusqlite::Connection::open(&db_path).expect("conn");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM staging_events WHERE intent_id = ?1",
+                params![intent_id.to_string()],
+                |row| row.get(0),
+            )
+            .expect("count query");
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn sqlite_event_store_records_action_plan_event() {
+        let db_path = temp_db_path();
+        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let plan = ActionPlan::new(Uuid::new_v4(), true);
+
+        store
+            .record_action_plan_event(&plan)
+            .expect("record action plan");
+
+        // Verify by checking the database directly.
+        let conn = rusqlite::Connection::open(&db_path).expect("conn");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM action_plan_events", [], |row| {
+                row.get(0)
+            })
+            .expect("count query");
+
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn sqlite_event_store_replays_decision_explanation_by_id() {
+        let db_path = temp_db_path();
+        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+
+        // Record a decision through the DecisionLog trait.
+        let log: DynDecisionLog = Arc::new(store);
+        let decision = sample_decision_with_summary("Selected hot model.");
+
+        futures::executor::block_on(log.record_decision(&decision)).expect("record");
+
+        // Retrieve explanation by ID using get_decision_explanation.
+        let stored_store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let explanation = stored_store
+            .get_decision_explanation(decision.id)
+            .expect("get explanation");
+
+        assert!(explanation.is_some());
+        let exp = explanation.expect("has explanation");
+        assert_eq!(exp.summary, "Selected hot model.");
+
+        let _ = std::fs::remove_file(&db_path);
     }
 }

--- a/crates/anemoi-telemetry/src/lib.rs
+++ b/crates/anemoi-telemetry/src/lib.rs
@@ -1,9 +1,8 @@
-use anemoi_core::{ActionPlan, Decision, RuntimeSnapshot};
+use anemoi_core::{ActionPlan, Decision, ResidencyState, RuntimeSnapshot};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
-use rusqlite::{params, Connection};
-use serde::{Deserialize, Serialize};
+use rusqlite::{params, Connection, OptionalExtension};
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -30,50 +29,18 @@ pub trait DecisionLog: Send + Sync {
 
 pub type DynDecisionLog = Arc<dyn DecisionLog>;
 
-/// Event record types for the durable event store.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "event_type")]
-pub enum StoredEvent {
-    #[serde(rename = "decision")]
-    Decision {
-        id: Uuid,
-        decision: Decision,
-        recorded_at: DateTime<Utc>,
-    },
-    #[serde(rename = "runtime_snapshot")]
-    RuntimeSnapshot {
-        id: Uuid,
-        runtime_id: String,
-        snapshot: RuntimeSnapshot,
-        observed_at: DateTime<Utc>,
-    },
-    #[serde(rename = "resident_transition")]
-    ResidentTransition {
-        id: Uuid,
-        model_id: String,
-        from_state: String,
-        to_state: String,
-        evidence_source: Option<String>,
-        decision_id: Option<Uuid>,
-        transition_recorded_at: DateTime<Utc>,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StoredActionPlan {
-    pub decision_id: Uuid,
-    pub actions_json: String,
-}
-
-/// SQLite-backed event store for durable history.
-/// Uses a mutex to make the connection safe across async contexts.
+/// SQLite-backed durable event store.
+///
+/// SQLite is the source of truth: `get_decision`/`list_decisions` read from the
+/// database, so decisions survive a process restart. A `parking_lot::Mutex`
+/// serializes access to the single connection across async contexts.
 pub struct SqliteEventStore {
     conn: Mutex<Connection>,
-    memory_log: InMemoryDecisionLog,
 }
 
 impl SqliteEventStore {
-    /// Creates a new SQLite database at the given path with initialized tables.
+    /// Opens (creating if needed) a SQLite database at `path` and ensures the
+    /// event tables exist. Reopening the same path sees previously written rows.
     pub fn create(path: impl AsRef<Path>) -> Result<Self, TelemetryError> {
         let path = path.as_ref();
         if let Some(parent) = path.parent() {
@@ -83,22 +50,21 @@ impl SqliteEventStore {
         }
 
         let conn = Connection::open(path)?;
-
-        // Enable WAL mode for better concurrent read performance.
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;
 
         let store = Self {
             conn: Mutex::new(conn),
-            memory_log: InMemoryDecisionLog::default(),
         };
         store.init_tables()?;
         Ok(store)
     }
 
     fn init_tables(&self) -> Result<(), TelemetryError> {
-        // Create tables using the connection directly.
-        let guard = self.conn.lock();
-        guard.execute_batch(
+        // All event tables are append-only. `resident_events` follows the
+        // schema in GitHub issue #12: evidence_source is NOT NULL (a transition
+        // is never recorded anonymously); decision_id and note are nullable
+        // because observation-only transitions have no triggering decision.
+        self.conn.lock().execute_batch(
             r#"
             CREATE TABLE IF NOT EXISTS decisions (
                 id TEXT PRIMARY KEY,
@@ -111,14 +77,16 @@ impl SqliteEventStore {
                 snapshot_json TEXT NOT NULL,
                 observed_at TEXT NOT NULL
             );
-            CREATE TABLE IF NOT EXISTS resident_transitions (
+            CREATE TABLE IF NOT EXISTS resident_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 model_id TEXT NOT NULL,
+                runtime_id TEXT NOT NULL,
                 from_state TEXT NOT NULL,
                 to_state TEXT NOT NULL,
-                evidence_source TEXT,
+                observed_at TEXT NOT NULL,
+                evidence_source TEXT NOT NULL,
                 decision_id TEXT,
-                transition_recorded_at TEXT NOT NULL
+                note TEXT
             );
             CREATE TABLE IF NOT EXISTS staging_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -141,46 +109,79 @@ impl SqliteEventStore {
         Ok(())
     }
 
-    /// Records a runtime snapshot event.
+    /// Records a runtime snapshot event with the time it was observed.
     pub fn record_runtime_snapshot(
         &self,
         id: Uuid,
         runtime_id: &str,
         snapshot: &RuntimeSnapshot,
+        observed_at: DateTime<Utc>,
     ) -> Result<(), TelemetryError> {
         let json = serde_json::to_string(snapshot)?;
-        let observed_at = Utc::now().to_rfc3339();
         self.conn.lock().execute(
             "INSERT INTO runtime_snapshots (event_id, runtime_id, snapshot_json, observed_at) VALUES (?1, ?2, ?3, ?4)",
-            params![id.to_string(), runtime_id, &json, &observed_at],
+            params![id.to_string(), runtime_id, &json, observed_at.to_rfc3339()],
         )?;
         Ok(())
     }
 
-    /// Records a resident transition event.
-    pub fn record_resident_transition(
+    /// Records a resident state transition (issue #12). `evidence_source` is
+    /// required — which adapter and inspection round observed the transition —
+    /// so a transition is never anonymous. `decision_id` is `None` for
+    /// observation-only transitions that no decision triggered.
+    // The argument list mirrors the issue #12 `resident_events` columns; each is
+    // a distinct, required field rather than incidental parameter sprawl.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_resident_event(
         &self,
         model_id: &str,
-        from_state: &str,
-        to_state: &str,
-        evidence_source: Option<&str>,
+        runtime_id: &str,
+        from_state: &ResidencyState,
+        to_state: &ResidencyState,
+        observed_at: DateTime<Utc>,
+        evidence_source: &str,
         decision_id: Option<Uuid>,
+        note: Option<&str>,
     ) -> Result<(), TelemetryError> {
-        let recorded_at = Utc::now().to_rfc3339();
         self.conn.lock().execute(
-            r#"INSERT INTO resident_transitions
-               (model_id, from_state, to_state, evidence_source, decision_id, transition_recorded_at)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+            r#"INSERT INTO resident_events
+               (model_id, runtime_id, from_state, to_state, observed_at, evidence_source, decision_id, note)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
             params![
                 model_id,
-                from_state,
-                to_state,
+                runtime_id,
+                residency_state_str(from_state),
+                residency_state_str(to_state),
+                observed_at.to_rfc3339(),
                 evidence_source,
                 decision_id.map(|id| id.to_string()),
-                recorded_at
+                note,
             ],
         )?;
         Ok(())
+    }
+
+    /// Reads every resident transition for a model in insert order.
+    pub fn resident_events(&self, model_id: &str) -> Result<Vec<ResidentEvent>, TelemetryError> {
+        let guard = self.conn.lock();
+        let mut stmt = guard.prepare(
+            r#"SELECT model_id, runtime_id, from_state, to_state, observed_at,
+                      evidence_source, decision_id, note
+               FROM resident_events WHERE model_id = ?1 ORDER BY id"#,
+        )?;
+        let rows = stmt.query_map(params![model_id], |row| {
+            Ok(ResidentEvent {
+                model_id: row.get(0)?,
+                runtime_id: row.get(1)?,
+                from_state: row.get(2)?,
+                to_state: row.get(3)?,
+                observed_at: row.get(4)?,
+                evidence_source: row.get(5)?,
+                decision_id: row.get(6)?,
+                note: row.get(7)?,
+            })
+        })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     /// Records a staging event.
@@ -193,7 +194,6 @@ impl SqliteEventStore {
         reason: &str,
         state: &str,
     ) -> Result<(), TelemetryError> {
-        let recorded_at = Utc::now().to_rfc3339();
         self.conn.lock().execute(
             "INSERT INTO staging_events
                (intent_id, decision_id, background_model, target_runtime, reason, state, recorded_at)
@@ -205,7 +205,7 @@ impl SqliteEventStore {
                 target_runtime,
                 reason,
                 state,
-                recorded_at
+                Utc::now().to_rfc3339(),
             ],
         )?;
         Ok(())
@@ -214,87 +214,130 @@ impl SqliteEventStore {
     /// Records an action plan event.
     pub fn record_action_plan_event(&self, plan: &ActionPlan) -> Result<(), TelemetryError> {
         let json = serde_json::to_string(plan)?;
-        let recorded_at = Utc::now().to_rfc3339();
         self.conn.lock().execute(
             "INSERT INTO action_plan_events (decision_id, plan_json, recorded_at) VALUES (?1, ?2, ?3)",
-            params![plan.decision_id.to_string(), &json, recorded_at],
+            params![plan.decision_id.to_string(), &json, Utc::now().to_rfc3339()],
         )?;
         Ok(())
     }
 
-    /// Retrieves a decision explanation by ID.
+    /// Replays a decision's explanation from durable storage, used by
+    /// `/explain/:id` to answer why a decision happened after a restart.
     pub fn get_decision_explanation(
         &self,
         id: Uuid,
     ) -> Result<Option<anemoi_core::Explanation>, TelemetryError> {
-        let guard = self.conn.lock();
-        let mut stmt = guard.prepare("SELECT decision_json FROM decisions WHERE id = ?1")?;
-        let result: Option<String> = stmt
-            .query_row(params![id.to_string()], |row| row.get(0))
-            .ok();
-        match result {
-            Some(json_str) => {
-                drop(stmt);
-                drop(guard);
-                let decision: Decision = serde_json::from_str(&json_str)?;
-                Ok(Some(decision.explanation))
-            }
-            None => Ok(None),
-        }
+        Ok(self.read_decision(id)?.map(|decision| decision.explanation))
     }
 
-    /// Records a decision to in-memory log.
-    pub async fn record_to_memory(&self, decision: &Decision) -> Result<(), TelemetryError> {
-        self.memory_log.record_decision(decision).await
+    fn read_decision(&self, id: Uuid) -> Result<Option<Decision>, TelemetryError> {
+        let guard = self.conn.lock();
+        let mut stmt = guard.prepare("SELECT decision_json FROM decisions WHERE id = ?1")?;
+        let json: Option<String> = stmt
+            .query_row(params![id.to_string()], |row| row.get(0))
+            .optional()?;
+        json.map(|json| serde_json::from_str(&json).map_err(Into::into))
+            .transpose()
     }
 }
 
-impl Default for SqliteEventStore {
-    fn default() -> Self {
-        let conn = Connection::open_in_memory().expect("in-memory sqlite");
-        let store = Self {
-            conn: Mutex::new(conn),
-            memory_log: InMemoryDecisionLog::default(),
-        };
-        store.init_tables().expect("init tables");
-        store
-    }
+/// A resident transition row read back from `resident_events`. States are the
+/// snake_case `ResidencyState` strings as stored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResidentEvent {
+    pub model_id: String,
+    pub runtime_id: String,
+    pub from_state: String,
+    pub to_state: String,
+    pub observed_at: String,
+    pub evidence_source: String,
+    pub decision_id: Option<String>,
+    pub note: Option<String>,
+}
+
+fn residency_state_str(state: &ResidencyState) -> String {
+    serde_json::to_value(state)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_default()
 }
 
 #[async_trait]
 impl DecisionLog for SqliteEventStore {
     async fn record_decision(&self, decision: &Decision) -> Result<(), TelemetryError> {
-        // Also update in-memory log.
-        self.record_to_memory(decision).await?;
-
-        let id = decision.id.to_string();
         let json = serde_json::to_string(decision)?;
-        let recorded_at = Utc::now().to_rfc3339();
-
         self.conn.lock().execute(
             "INSERT OR REPLACE INTO decisions (id, decision_json, recorded_at) VALUES (?1, ?2, ?3)",
-            params![&id, &json, &recorded_at],
+            params![decision.id.to_string(), &json, Utc::now().to_rfc3339()],
         )?;
         Ok(())
     }
 
     async fn get_decision(&self, id: Uuid) -> Result<Option<Decision>, TelemetryError> {
-        self.memory_log.get_decision(id).await
+        self.read_decision(id)
     }
 
     async fn list_decisions(&self) -> Result<Vec<Decision>, TelemetryError> {
-        self.memory_log.list_decisions().await
+        let guard = self.conn.lock();
+        let mut stmt = guard.prepare("SELECT decision_json FROM decisions ORDER BY rowid")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let mut decisions = Vec::new();
+        for json in rows {
+            decisions.push(serde_json::from_str(&json?)?);
+        }
+        Ok(decisions)
     }
 }
 
+/// Builds the decision log for the daemon and CLI.
+///
+/// Precedence: `ANEMOI_DATABASE_URL` (a `sqlite://` URL) selects the durable
+/// SQLite store; otherwise a JSONL path appends to a file-backed log; otherwise
+/// an in-memory log. This is the single place production wires the store, so a
+/// `sqlite://` URL reaches `SqliteEventStore` from the real binary.
 pub fn default_decision_log(jsonl_path: Option<PathBuf>) -> Result<DynDecisionLog, TelemetryError> {
-    jsonl_path
-        .map(JsonlDecisionLog::new)
-        .transpose()
-        .map(|log| {
-            log.map(|log| Arc::new(log) as DynDecisionLog)
-                .unwrap_or_else(|| Arc::new(InMemoryDecisionLog::default()))
-        })
+    let database_url = std::env::var("ANEMOI_DATABASE_URL")
+        .ok()
+        .filter(|url| !url.is_empty());
+    decision_log_from(database_url.as_deref(), jsonl_path)
+}
+
+/// Pure constructor used by `default_decision_log` and by tests, so behavior can
+/// be exercised without mutating process environment.
+pub fn decision_log_from(
+    database_url: Option<&str>,
+    jsonl_path: Option<PathBuf>,
+) -> Result<DynDecisionLog, TelemetryError> {
+    if let Some(url) = database_url {
+        let path = sqlite_path_from_url(url).ok_or_else(|| {
+            TelemetryError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("unsupported ANEMOI_DATABASE_URL: {url}"),
+            ))
+        })?;
+        return Ok(Arc::new(SqliteEventStore::create(path)?));
+    }
+    if let Some(path) = jsonl_path {
+        return Ok(Arc::new(JsonlDecisionLog::new(path)?));
+    }
+    Ok(Arc::new(InMemoryDecisionLog::default()))
+}
+
+/// Parses a `sqlite://` URL into a filesystem path. `sqlite:///var/lib/x.db`
+/// yields the absolute Unix path `/var/lib/x.db`; on Windows a leading slash
+/// before a drive letter (`/C:/x.db`) is dropped.
+fn sqlite_path_from_url(url: &str) -> Option<PathBuf> {
+    let rest = url.strip_prefix("sqlite://")?;
+    let bytes = rest.as_bytes();
+    let trimmed = if bytes.first() == Some(&b'/')
+        && bytes.get(1).is_some_and(u8::is_ascii_alphabetic)
+        && bytes.get(2) == Some(&b':')
+    {
+        &rest[1..]
+    } else {
+        rest
+    };
+    Some(PathBuf::from(trimmed))
 }
 
 #[derive(Debug, Default)]
@@ -551,19 +594,35 @@ mod tests {
         std::env::temp_dir().join(format!("anemoi-{}.db", Uuid::new_v4()))
     }
 
+    fn sample_snapshot() -> RuntimeSnapshot {
+        RuntimeSnapshot {
+            runtime_id: anemoi_core::RuntimeId("mock".to_string()),
+            available: true,
+            residents: Vec::new(),
+            configured_models: vec![],
+            memory: anemoi_core::RuntimeMemorySnapshot::default(),
+            active_requests: Vec::new(),
+        }
+    }
+
     #[test]
     fn sqlite_event_store_records_decision_event() {
         let db_path = temp_db_path();
-        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+        let decision = sample_decision_with_summary("Denied: no runnable candidate.");
 
-        // Record the decision
-        futures::executor::block_on(Arc::new(store).record_decision(&sample_decision()))
-            .expect("record");
+        // Record through the original store, then drop it.
+        {
+            let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+            futures::executor::block_on(store.record_decision(&decision)).expect("record");
+        }
 
-        // Verify by retrieving from a new store instance
-        let stored_store = SqliteEventStore::create(&db_path).expect("sqlite event store");
-        let explanation = stored_store.get_decision_explanation(sample_decision().id);
-        assert!(explanation.is_ok());
+        // Reopen a fresh store on the same file: the decision survives the
+        // "restart" and round-trips identically.
+        let reopened = SqliteEventStore::create(&db_path).expect("reopen sqlite event store");
+        let stored = futures::executor::block_on(reopened.get_decision(decision.id))
+            .expect("get")
+            .expect("decision is durable across reopen");
+        assert_eq!(stored, decision);
 
         let _ = std::fs::remove_file(&db_path);
     }
@@ -571,106 +630,165 @@ mod tests {
     #[test]
     fn sqlite_event_store_records_runtime_snapshot_event() {
         let db_path = temp_db_path();
-        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
-        let snapshot = RuntimeSnapshot {
-            runtime_id: anemoi_core::RuntimeId("mock".to_string()),
-            available: true,
-            residents: Vec::new(),
-            configured_models: vec![],
-            memory: anemoi_core::RuntimeMemorySnapshot::default(),
-            active_requests: Vec::new(),
-        };
+        let snapshot = sample_snapshot();
         let event_id = Uuid::new_v4();
-        store
-            .record_runtime_snapshot(event_id, "mock", &snapshot)
-            .expect("record snapshot");
+        let observed_at = Utc::now();
 
-        // Verify by checking the database directly.
+        {
+            let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+            store
+                .record_runtime_snapshot(event_id, "mock", &snapshot, observed_at)
+                .expect("record snapshot");
+        }
+
+        // Reopen and read the row back: the stored JSON deserializes to the
+        // same snapshot and keeps the observed-at timestamp.
         let conn = rusqlite::Connection::open(&db_path).expect("conn");
-        let count: i64 = conn
+        let (json, stored_observed_at): (String, String) = conn
             .query_row(
-                "SELECT COUNT(*) FROM runtime_snapshots WHERE event_id = ?1",
+                "SELECT snapshot_json, observed_at FROM runtime_snapshots WHERE event_id = ?1",
                 params![event_id.to_string()],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
-            .expect("count query");
-        assert_eq!(count, 1);
+            .expect("snapshot row");
+        let roundtrip: RuntimeSnapshot = serde_json::from_str(&json).expect("snapshot json");
+        assert_eq!(roundtrip, snapshot);
+        assert_eq!(stored_observed_at, observed_at.to_rfc3339());
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn sqlite_event_store_records_resident_event() {
+        // Issue #12: a resident transition is recorded with a required
+        // evidence_source and survives a reopen, read back via resident_events.
+        let db_path = temp_db_path();
+        let observed_at = Utc::now();
+        let decision_id = Uuid::new_v4();
+
+        {
+            let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+            store
+                .record_resident_event(
+                    "qwen35_a3b",
+                    "mock",
+                    &ResidencyState::WarmCpu,
+                    &ResidencyState::HotGpu,
+                    observed_at,
+                    "mock-adapter inspect round 7",
+                    Some(decision_id),
+                    Some("promoted to GPU"),
+                )
+                .expect("record resident event");
+        }
+
+        let reopened = SqliteEventStore::create(&db_path).expect("reopen sqlite event store");
+        let events = reopened
+            .resident_events("qwen35_a3b")
+            .expect("resident events");
+        assert_eq!(
+            events,
+            vec![ResidentEvent {
+                model_id: "qwen35_a3b".to_string(),
+                runtime_id: "mock".to_string(),
+                from_state: "warm_cpu".to_string(),
+                to_state: "hot_gpu".to_string(),
+                observed_at: observed_at.to_rfc3339(),
+                evidence_source: "mock-adapter inspect round 7".to_string(),
+                decision_id: Some(decision_id.to_string()),
+                note: Some("promoted to GPU".to_string()),
+            }]
+        );
+
         let _ = std::fs::remove_file(&db_path);
     }
 
     #[test]
     fn sqlite_event_store_records_staging_event() {
         let db_path = temp_db_path();
-        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
         let decision_id = Uuid::new_v4();
         let intent_id = Uuid::new_v4();
 
-        store
-            .record_staging_event(
-                intent_id,
-                decision_id,
-                "qwen35_a3b",
-                "mock",
-                "background staging test",
-                "pending",
-            )
-            .expect("record staging");
+        {
+            let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+            store
+                .record_staging_event(
+                    intent_id,
+                    decision_id,
+                    "qwen35_a3b",
+                    "mock",
+                    "background staging test",
+                    "pending",
+                )
+                .expect("record staging");
+        }
 
-        // Verify by checking the database directly.
+        // Reopen the file and read the stored columns back.
         let conn = rusqlite::Connection::open(&db_path).expect("conn");
-        let count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM staging_events WHERE intent_id = ?1",
+        let (background_model, target_runtime, reason, state): (String, String, String, String) =
+            conn.query_row(
+                "SELECT background_model, target_runtime, reason, state
+                 FROM staging_events WHERE intent_id = ?1",
                 params![intent_id.to_string()],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
-            .expect("count query");
-        assert_eq!(count, 1);
+            .expect("staging row");
+        assert_eq!(background_model, "qwen35_a3b");
+        assert_eq!(target_runtime, "mock");
+        assert_eq!(reason, "background staging test");
+        assert_eq!(state, "pending");
+
         let _ = std::fs::remove_file(&db_path);
     }
 
     #[test]
     fn sqlite_event_store_records_action_plan_event() {
         let db_path = temp_db_path();
-        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
-        let plan = ActionPlan::new(Uuid::new_v4(), true);
+        let decision_id = Uuid::new_v4();
+        let plan = ActionPlan::new(decision_id, true);
 
-        store
-            .record_action_plan_event(&plan)
-            .expect("record action plan");
+        {
+            let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
+            store
+                .record_action_plan_event(&plan)
+                .expect("record action plan");
+        }
 
-        // Verify by checking the database directly.
+        // Reopen the file: the stored plan JSON round-trips to the same plan.
         let conn = rusqlite::Connection::open(&db_path).expect("conn");
-        let count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM action_plan_events", [], |row| {
-                row.get(0)
-            })
-            .expect("count query");
+        let (stored_decision_id, json): (String, String) = conn
+            .query_row(
+                "SELECT decision_id, plan_json FROM action_plan_events WHERE decision_id = ?1",
+                params![decision_id.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("action plan row");
+        assert_eq!(stored_decision_id, decision_id.to_string());
+        let roundtrip: ActionPlan = serde_json::from_str(&json).expect("plan json");
+        assert_eq!(roundtrip, plan);
 
-        assert_eq!(count, 1);
         let _ = std::fs::remove_file(&db_path);
     }
 
     #[test]
     fn sqlite_event_store_replays_decision_explanation_by_id() {
         let db_path = temp_db_path();
-        let store = SqliteEventStore::create(&db_path).expect("sqlite event store");
-
-        // Record a decision through the DecisionLog trait.
-        let log: DynDecisionLog = Arc::new(store);
         let decision = sample_decision_with_summary("Selected hot model.");
 
-        futures::executor::block_on(log.record_decision(&decision)).expect("record");
+        // Record a decision through the DecisionLog trait, then drop the store.
+        {
+            let log: DynDecisionLog =
+                Arc::new(SqliteEventStore::create(&db_path).expect("sqlite event store"));
+            futures::executor::block_on(log.record_decision(&decision)).expect("record");
+        }
 
-        // Retrieve explanation by ID using get_decision_explanation.
-        let stored_store = SqliteEventStore::create(&db_path).expect("sqlite event store");
-        let explanation = stored_store
+        // Reopen and replay the explanation by id.
+        let reopened = SqliteEventStore::create(&db_path).expect("reopen sqlite event store");
+        let explanation = reopened
             .get_decision_explanation(decision.id)
-            .expect("get explanation");
-
-        assert!(explanation.is_some());
-        let exp = explanation.expect("has explanation");
-        assert_eq!(exp.summary, "Selected hot model.");
+            .expect("get explanation")
+            .expect("explanation is durable across reopen");
+        assert_eq!(explanation, decision.explanation);
 
         let _ = std::fs::remove_file(&db_path);
     }

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -47,7 +47,7 @@ hardening when the local toolchain has the `clippy` component installed.
 | 24 resource pressure model | Candidate scoring uses explicit VRAM, RAM, KV, load, and active-request pressure evidence. | `anemoi-policy`, `anemoi-core` | Passing |
 | 25 eviction and pinning policy | Keep-hot workers are protected and eviction plans are explainable and gated. | `anemoi-policy`, `anemoi-core`, `anemoi-runtime` | Passing |
 | 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Passing |
-| 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Pending |
+| 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Passing |
 | 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Pending |
 
 ## Current Focus
@@ -245,3 +245,13 @@ Prompt 20 passed with:
 - `ANEMOI_ENABLE_LIVE_EXECUTE=1` opt-in guard for non-mock execution
 - `docs/live_validation/controlled-execution-gate.md` with approval checklist
   and execution path table
+
+Prompt 27 passed with:
+
+- `sqlite_event_store_records_decision_event`
+- `sqlite_event_store_records_runtime_snapshot_event`
+- `sqlite_event_store_records_staging_event`
+- `sqlite_event_store_records_action_plan_event`
+- `sqlite_event_store_replays_decision_explanation_by_id`
+- `daemon_starts_with_memory_store_when_database_url_is_missing`
+- `daemon_uses_sqlite_store_when_database_url_is_present`

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -255,3 +255,11 @@ Prompt 27 passed with:
 - `sqlite_event_store_replays_decision_explanation_by_id`
 - `daemon_starts_with_memory_store_when_database_url_is_missing`
 - `daemon_uses_sqlite_store_when_database_url_is_present`
+- `sqlite_event_store_records_resident_event` (issue #12 `resident_events`)
+
+SQLite is the source of truth: `get_decision`/`list_decisions` read from the
+database, so every required test reopens the file (a process "restart") and
+asserts the recorded value round-trips, rather than asserting `is_ok`. The
+`resident_events` table follows the issue #12 schema with a NOT NULL
+`evidence_source`. `execution_events`/`policy_events` tables are deferred: no
+required test exercises them and they belong to later prompts (21-23).


### PR DESCRIPTION
## Summary
- Makes the durable event store actually durable: SQLite is the source of truth, so `get_decision`/`list_decisions` read from the database and decisions survive a process restart.
- Rewrites all required tests to reopen the file (a process "restart") and assert the recorded value round-trips via `assert_eq`, replacing the prior `is_ok`/`is_some` assertions that never observed durability.
- Adds the issue #12 `resident_events` table (NOT NULL `evidence_source`, nullable `decision_id`/`note`) with record/read paths and a round-trip test.
- Removes the unreachable test-only `create_decision_log` and rewrites the daemon store-selection tests to exercise the real `default_decision_log` -> `decision_log_from` path (the one the binary uses) with a restart round-trip.

This is the repair of the graded-F prompt #27 work in `d47c218`, kept on top of that commit so history shows the defect and its fix. The exact defect class is now caught by `anemoi-guard` (no violations).

### Deferral
`execution_events`/`policy_events` tables are intentionally omitted: no required test exercises them and they belong to later prompts (21-23). Adding them now would be speculative.

## Required tests (all passing)
- `sqlite_event_store_records_decision_event`
- `sqlite_event_store_records_runtime_snapshot_event`
- `sqlite_event_store_records_staging_event`
- `sqlite_event_store_records_action_plan_event`
- `sqlite_event_store_replays_decision_explanation_by_id`
- `sqlite_event_store_records_resident_event` (issue #12)
- `daemon_starts_with_memory_store_when_database_url_is_missing`
- `daemon_uses_sqlite_store_when_database_url_is_present`

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p anemoi-guard -- crates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)