### PR TITLE
feat(daemon): OpenAI-compatible inference forwarding gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "futures",
  "serde",
  "serde_json",
  "tokio",
@@ -123,6 +124,7 @@ dependencies = [
  "anemoi-core",
  "async-trait",
  "chrono",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -1288,6 +1290,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1309,12 +1312,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2092,6 +2097,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 parking_lot = "0.12"
 regex = "1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/anemoi-daemon/Cargo.toml
+++ b/crates/anemoi-daemon/Cargo.toml
@@ -12,6 +12,7 @@ anemoi-telemetry.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 chrono.workspace = true
+futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
@@ -22,4 +23,5 @@ uuid.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+tokio.workspace = true
 tower.workspace = true

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -1,14 +1,18 @@
 use anemoi_core::{
-    ActionKind, ActionPlan, AnemoiConfig, Decision, DecisionAction, InferenceRequest, ModelId,
-    ModelResident, ResidencyState, RuntimeId, RuntimeSnapshot,
+    ActionKind, ActionPlan, AnemoiConfig, Decision, DecisionAction, DomainId, ExecutionMode,
+    InferenceRequest, ModelId, ModelResident, RequestId, ResidencyState, RuntimeId,
+    RuntimeSnapshot,
 };
 use anemoi_policy::{EvictionCandidateResident, EvictionPlan, EvictionRequest, Scheduler};
 use anemoi_runtime::{
-    DynRuntimeAdapter, LlamaCppAdapter, LlamaSwapAdapter, MockRuntimeAdapter, OllamaAdapter,
+    DynRuntimeAdapter, ForwardedChatCompletion, LlamaCppAdapter, LlamaSwapAdapter,
+    MockRuntimeAdapter, OllamaAdapter,
 };
 use anemoi_telemetry::{DynDecisionLog, InMemoryDecisionLog};
+use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
@@ -393,6 +397,10 @@ pub struct AppState {
     decision_log: DynDecisionLog,
     reconciler: Reconciler,
     staging_worker: StagingWorker,
+    /// Test seam for the live-execute gate. `None` reads the real
+    /// `ANEMOI_ENABLE_LIVE_EXECUTE` env var (production); `Some(_)` overrides it
+    /// so tests can exercise the gate without mutating process-global state.
+    live_execute: Option<bool>,
 }
 
 impl AppState {
@@ -464,6 +472,34 @@ impl AppState {
             decision_log,
             reconciler,
             staging_worker,
+            live_execute: None,
+        })
+    }
+
+    /// Whether forwarding to a non-mock runtime is permitted. Production reads
+    /// `ANEMOI_ENABLE_LIVE_EXECUTE=1`; tests can override via
+    /// [`AppState::with_live_execute`].
+    pub fn live_execute_enabled(&self) -> bool {
+        self.live_execute.unwrap_or_else(live_execution_enabled)
+    }
+
+    #[cfg(test)]
+    fn with_live_execute(mut self, enabled: bool) -> Self {
+        self.live_execute = Some(enabled);
+        self
+    }
+
+    /// Resolves the forward target (base URL + auth token) for a runtime from
+    /// config. Returns `None` when the runtime is unknown or has no base URL.
+    fn runtime_forward_target(&self, runtime_id: &str) -> Option<anemoi_runtime::ForwardTarget> {
+        let config = self
+            .config
+            .runtimes
+            .get(&RuntimeId(runtime_id.to_string()))?;
+        let base_url = config.base_url.clone()?;
+        Some(anemoi_runtime::ForwardTarget {
+            base_url,
+            auth_token: config.auth_token.clone(),
         })
     }
 
@@ -505,6 +541,7 @@ impl AppState {
             decision_log: Arc::new(InMemoryDecisionLog::default()),
             reconciler,
             staging_worker,
+            live_execute: None,
         })
     }
 
@@ -2241,6 +2278,280 @@ runtimes:
             "decide burst must reuse the reconciler cache; got {total} inspects"
         );
     }
+
+    fn chat_body(model: &str) -> Value {
+        serde_json::json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": "hello" }],
+        })
+    }
+
+    async fn body_value(response: Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        serde_json::from_slice(&bytes).expect("json body")
+    }
+
+    async fn body_text(response: Response) -> String {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        String::from_utf8(bytes.to_vec()).expect("utf8 body")
+    }
+
+    fn decision_id_header(response: &Response) -> Uuid {
+        let raw = response
+            .headers()
+            .get("x-anemoi-decision-id")
+            .expect("x-anemoi-decision-id header")
+            .to_str()
+            .expect("header is ascii");
+        Uuid::parse_str(raw).expect("decision id is a uuid")
+    }
+
+    /// Config whose only runtime is a non-mock (ollama) adapter pointed at a dead
+    /// port. The reconciler is pre-seeded by the caller so `decide` selects this
+    /// runtime without any live `inspect()`.
+    fn non_mock_gateway_state(live_execute: bool) -> AppState {
+        let yaml = r#"
+domains:
+  coding:
+    rosters:
+      - ollama_group
+residency_groups:
+  ollama_group:
+    purpose:
+      - test
+    keep_hot: true
+    allow_background_load: false
+    models:
+      - llama8b
+models:
+  llama8b:
+    family: llama
+    parameter_class: 8b
+    context_window: 8192
+    vram_required_mb: 8000
+    ram_required_mb: 10000
+    cold_load_estimate_ms: 12000
+    supports_streaming: true
+    supported_runtimes:
+      - remote
+runtimes:
+  remote:
+    adapter: ollama
+    base_url: http://127.0.0.1:9
+    initial_residents:
+      - model_id: llama8b
+        state: hot_gpu
+        vram_mb: 8000
+        ram_mb: 10000
+continuity:
+  keep_small_worker_hot: true
+  background_load: false
+  max_blank_wait_ms: 1500
+  prefer_degraded_response_over_silence: true
+"#;
+        let config = AnemoiConfig::from_yaml_str(yaml).expect("non-mock config");
+        AppState::with_mock_residents(config, HashMap::new())
+            .expect("state")
+            .with_live_execute(live_execute)
+    }
+
+    fn remote_hot_snapshot() -> RuntimeSnapshot {
+        RuntimeSnapshot {
+            runtime_id: RuntimeId("remote".to_string()),
+            available: true,
+            residents: vec![ModelResident {
+                model_id: ModelId("llama8b".to_string()),
+                state: ResidencyState::HotGpu,
+                vram_mb: Some(8000),
+                ram_mb: Some(10000),
+                kv_cache_mb: None,
+                loaded_since: Some(chrono::Utc::now()),
+            }],
+            configured_models: vec![ModelId("llama8b".to_string())],
+            memory: anemoi_core::RuntimeMemorySnapshot::default(),
+            active_requests: vec![],
+        }
+    }
+
+    #[test]
+    fn inference_gateway_maps_model_field_to_domain() {
+        assert_eq!(resolve_domain("coding"), "coding");
+        assert_eq!(resolve_domain("general"), "general");
+    }
+
+    #[test]
+    fn inference_gateway_strips_anemoi_prefix_from_model_field() {
+        assert_eq!(resolve_domain("anemoi-coding"), "coding");
+        // Only the leading `anemoi-` is stripped; bare names are unchanged.
+        assert_eq!(resolve_domain("coding"), "coding");
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_returns_error_for_unknown_domain() {
+        let response = test_router()
+            .oneshot(json_request("/v1/chat/completions", &chat_body("nonsense")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = body_value(response).await;
+        assert_eq!(body["error"]["type"], "anemoi_gateway_error");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .expect("message")
+                .contains("nonsense"),
+            "error should name the unknown domain"
+        );
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_runs_decide_before_forwarding() {
+        let log = Arc::new(InMemoryDecisionLog::default());
+        let state = AppState::new(example_config(), log.clone()).expect("state");
+
+        let response = router(state)
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let id = decision_id_header(&response);
+        assert!(
+            log.get_decision(id).await.expect("log").is_some(),
+            "a decision must be recorded before forwarding"
+        );
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_rewrites_model_to_selected_model() {
+        let response = test_router()
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let selected = response
+            .headers()
+            .get("x-anemoi-selected-model")
+            .expect("x-anemoi-selected-model header")
+            .to_str()
+            .expect("ascii")
+            .to_string();
+        assert_ne!(
+            selected, "coding",
+            "selected model must be a runtime model, not the domain"
+        );
+
+        // The mock runtime echoes the model it was asked to serve, proving the
+        // caller's domain hint was rewritten to the governed model id.
+        let body = body_text(response).await;
+        assert!(
+            body.contains(&selected),
+            "forwarded SSE body should reference the selected model `{selected}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_records_decision_in_telemetry() {
+        let log = Arc::new(InMemoryDecisionLog::default());
+        let state = AppState::new(example_config(), log.clone()).expect("state");
+
+        let response = router(state)
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        let id = decision_id_header(&response);
+        let recorded = log
+            .get_decision(id)
+            .await
+            .expect("log")
+            .expect("decision recorded in telemetry");
+        assert_eq!(recorded.id, id);
+        assert!(recorded.selected_model.is_some());
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_returns_decision_id_in_response_header() {
+        let response = test_router()
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // Parses as a uuid or panics.
+        let _ = decision_id_header(&response);
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_forwards_mock_without_live_execute_flag() {
+        // test_router has no live-execute flag set; the mock runtime must still
+        // forward because mock forwarding never touches a real runtime.
+        let response = test_router()
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_text(response).await;
+        assert!(
+            body.contains("data:"),
+            "mock forward should return an SSE stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_requires_live_execute_flag_for_non_mock() {
+        let state = non_mock_gateway_state(false);
+        state
+            .reconciler()
+            .update("remote", remote_hot_snapshot())
+            .await;
+
+        let response = router(state)
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = body_value(response).await;
+        assert_eq!(body["error"]["type"], "anemoi_gateway_error");
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_returns_structured_error_on_runtime_failure() {
+        let state = non_mock_gateway_state(true);
+        state
+            .reconciler()
+            .update("remote", remote_hot_snapshot())
+            .await;
+
+        let response = router(state)
+            .oneshot(json_request("/v1/chat/completions", &chat_body("coding")))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let id_header = response
+            .headers()
+            .get("x-anemoi-decision-id")
+            .expect("decision id header on forwarding failure")
+            .to_str()
+            .expect("ascii")
+            .to_string();
+        let body = body_value(response).await;
+        assert_eq!(body["error"]["type"], "anemoi_gateway_error");
+        assert_eq!(
+            body["error"]["decision_id"].as_str().expect("decision_id"),
+            id_header,
+            "structured error must carry the decision id"
+        );
+    }
 }
 
 pub fn router(state: AppState) -> Router {
@@ -2253,6 +2564,8 @@ pub fn router(state: AppState) -> Router {
         .route("/decisions/:id", get(decision))
         .route("/explain/:id", get(explain))
         .route("/staging", get(staging))
+        .route("/v1/models", get(list_models))
+        .route("/v1/chat/completions", post(chat_completions))
         .route("/openapi.json", get(openapi))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -2686,4 +2999,209 @@ async fn explain(
 
 fn internal_error(error: impl std::fmt::Display) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+// ===== Inference Forwarding Gateway (prompt 28) =====
+
+/// Latency budget applied to gateway-originated decisions when the caller does
+/// not express one. The OpenAI chat-completions schema has no budget field.
+const DEFAULT_GATEWAY_LATENCY_BUDGET_MS: u64 = 30_000;
+
+/// Treats the OpenAI `model` field as a governance domain hint, stripping the
+/// optional `anemoi-` prefix. `"coding"` and `"anemoi-coding"` both map to the
+/// `coding` domain.
+fn resolve_domain(model_field: &str) -> &str {
+    model_field.strip_prefix("anemoi-").unwrap_or(model_field)
+}
+
+fn decision_action_str(action: &DecisionAction) -> String {
+    serde_json::to_value(action)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_string))
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+struct ModelCatalog {
+    object: &'static str,
+    data: Vec<ModelCatalogEntry>,
+}
+
+#[derive(Serialize)]
+struct ModelCatalogEntry {
+    id: String,
+    object: &'static str,
+    owned_by: &'static str,
+    anemoi_domain: bool,
+}
+
+/// `GET /v1/models` — OpenAI-format catalog of governance **domains** (issue
+/// #15). Runtime model ids never appear here; the caller selects a domain and
+/// Anemoi governs which model serves it. No live inspection is triggered.
+async fn list_models(State(state): State<AppState>) -> Json<ModelCatalog> {
+    let mut data: Vec<ModelCatalogEntry> = state
+        .config
+        .domains
+        .keys()
+        .map(|domain| ModelCatalogEntry {
+            id: domain.to_string(),
+            object: "model",
+            owned_by: "anemoi",
+            anemoi_domain: true,
+        })
+        .collect();
+    data.sort_by(|a, b| a.id.cmp(&b.id));
+    Json(ModelCatalog {
+        object: "list",
+        data,
+    })
+}
+
+/// Builds an OpenAI-style structured error. When a decision was already made,
+/// its id is included in the body and echoed as `X-Anemoi-Decision-Id` so the
+/// caller can query `/explain/:id`.
+fn gateway_error(
+    status: StatusCode,
+    message: impl Into<String>,
+    decision_id: Option<Uuid>,
+) -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "message": message.into(),
+            "type": "anemoi_gateway_error",
+            "decision_id": decision_id.map(|id| id.to_string()),
+        }
+    });
+    let mut response = (status, Json(body)).into_response();
+    if let Some(id) = decision_id {
+        if let Ok(value) = HeaderValue::from_str(&id.to_string()) {
+            response.headers_mut().insert("x-anemoi-decision-id", value);
+        }
+    }
+    response
+}
+
+/// `POST /v1/chat/completions` — OpenAI-compatible inference forwarding. The
+/// caller names a domain in `model`; Anemoi decides which runtime model serves
+/// it, records the decision, rewrites `model` to the selected model, forwards
+/// to the runtime, and streams the response back. The caller never selects a
+/// runtime model directly.
+async fn chat_completions(
+    State(state): State<AppState>,
+    Json(mut body): Json<serde_json::Value>,
+) -> Response {
+    let Some(model_field) = body
+        .get("model")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return gateway_error(
+            StatusCode::BAD_REQUEST,
+            "request is missing a string `model` field",
+            None,
+        );
+    };
+    let domain = resolve_domain(&model_field).to_string();
+
+    // Unknown domain is rejected before any decision or forwarding.
+    if !state.config.domains.contains_key(&DomainId(domain.clone())) {
+        return gateway_error(
+            StatusCode::BAD_REQUEST,
+            format!("unknown domain `{domain}`"),
+            None,
+        );
+    }
+
+    // Run the same decision path as POST /decide; this records telemetry.
+    let request = InferenceRequest {
+        id: RequestId::new(),
+        domain: DomainId(domain.clone()),
+        mode: ExecutionMode::Interactive,
+        prompt_tokens_estimate: None,
+        max_output_tokens: None,
+        latency_budget_ms: Some(DEFAULT_GATEWAY_LATENCY_BUDGET_MS),
+        quality_floor: None,
+    };
+    let decision = match state.decide(&request).await {
+        Ok(decision) => decision,
+        Err(error) => {
+            return gateway_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string(), None)
+        }
+    };
+
+    let (Some(selected_model), Some(selected_runtime)) = (
+        decision.selected_model.clone(),
+        decision.selected_runtime.clone(),
+    ) else {
+        return gateway_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "no runnable model for domain `{domain}`: {}",
+                decision.explanation.summary
+            ),
+            Some(decision.id),
+        );
+    };
+
+    let runtime_id = selected_runtime.to_string();
+    let is_mock = state.runtime_adapter_type(&runtime_id) == Some("mock");
+    if !is_mock && !state.live_execute_enabled() {
+        return gateway_error(
+            StatusCode::FORBIDDEN,
+            "forwarding to a non-mock runtime requires ANEMOI_ENABLE_LIVE_EXECUTE=1",
+            Some(decision.id),
+        );
+    }
+
+    // The caller's domain hint is replaced with the governed model id.
+    body["model"] = serde_json::Value::String(selected_model.to_string());
+
+    let forwarded = if is_mock {
+        anemoi_runtime::mock_chat_completion(&selected_model.to_string())
+    } else {
+        let Some(target) = state.runtime_forward_target(&runtime_id) else {
+            return gateway_error(
+                StatusCode::BAD_GATEWAY,
+                format!("runtime `{runtime_id}` has no base_url configured"),
+                Some(decision.id),
+            );
+        };
+        match anemoi_runtime::forward_chat_completion(&target, &body).await {
+            Ok(forwarded) => forwarded,
+            Err(error) => {
+                return gateway_error(
+                    StatusCode::BAD_GATEWAY,
+                    format!("runtime forward failed: {error}"),
+                    Some(decision.id),
+                )
+            }
+        }
+    };
+
+    gateway_stream_response(forwarded, &decision, &selected_model)
+}
+
+fn gateway_stream_response(
+    forwarded: ForwardedChatCompletion,
+    decision: &Decision,
+    selected_model: &ModelId,
+) -> Response {
+    let status = StatusCode::from_u16(forwarded.status).unwrap_or(StatusCode::OK);
+    let content_type = forwarded
+        .content_type
+        .unwrap_or_else(|| "text/event-stream".to_string());
+    let builder = Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, content_type)
+        .header("x-anemoi-decision-id", decision.id.to_string())
+        .header("x-anemoi-selected-model", selected_model.to_string())
+        .header("x-anemoi-action", decision_action_str(&decision.action));
+    match builder.body(Body::from_stream(forwarded.body)) {
+        Ok(response) => response,
+        Err(error) => gateway_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            error.to_string(),
+            Some(decision.id),
+        ),
+    }
 }

--- a/crates/anemoi-runtime/Cargo.toml
+++ b/crates/anemoi-runtime/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 anemoi-core.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
+futures.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -4,6 +4,7 @@ use anemoi_core::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
+use futures::stream::{BoxStream, StreamExt};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
 use serde::Deserialize;
@@ -625,6 +626,87 @@ fn normalize_model_id(raw: &str) -> ModelId {
             .unwrap_or(leaf)
             .to_string(),
     )
+}
+
+/// Where a forwarded chat completion should go. `auth_token` originates from
+/// the environment (expanded at config load) and is never committed.
+#[derive(Debug, Clone)]
+pub struct ForwardTarget {
+    pub base_url: String,
+    pub auth_token: Option<String>,
+}
+
+/// A chat-completion response forwarded back from a runtime. The body is a
+/// stream so the caller can relay it without buffering (the inference gateway
+/// requirement).
+pub struct ForwardedChatCompletion {
+    pub status: u16,
+    pub content_type: Option<String>,
+    pub body: BoxStream<'static, Result<Vec<u8>, RuntimeError>>,
+}
+
+const FORWARD_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Forwards an OpenAI-style chat completion `body` to a runtime's
+/// `/v1/chat/completions` endpoint, injecting the runtime bearer token when one
+/// is configured. The response body is streamed straight through; only
+/// transport failures (connection refused, timeout) surface as an `Err`.
+pub async fn forward_chat_completion(
+    target: &ForwardTarget,
+    body: &serde_json::Value,
+) -> Result<ForwardedChatCompletion, RuntimeError> {
+    let base =
+        Url::parse(&target.base_url).map_err(|error| RuntimeError::Url(error.to_string()))?;
+    let url = base
+        .join("/v1/chat/completions")
+        .map_err(|error| RuntimeError::Url(error.to_string()))?;
+
+    let client = reqwest::Client::builder()
+        .timeout(FORWARD_TIMEOUT)
+        .build()?;
+    let mut request = client.post(url).json(body);
+    if let Some(token) = &target.auth_token {
+        request = request.bearer_auth(token);
+    }
+
+    let response = request.send().await?;
+    let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = response
+        .bytes_stream()
+        .map(|chunk| {
+            chunk
+                .map(|bytes| bytes.to_vec())
+                .map_err(RuntimeError::from)
+        })
+        .boxed();
+
+    Ok(ForwardedChatCompletion {
+        status,
+        content_type,
+        body,
+    })
+}
+
+/// Builds a deterministic OpenAI-style SSE response for the mock runtime. The
+/// payload echoes `selected_model`, so a test can confirm the gateway rewrote
+/// the `model` field to the decision's selected model. No network is involved.
+pub fn mock_chat_completion(selected_model: &str) -> ForwardedChatCompletion {
+    let chunk = format!(
+        "data: {{\"object\":\"chat.completion.chunk\",\"model\":\"{selected_model}\",\
+\"choices\":[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":\"mock response from {selected_model}\"}}}}]}}\n\n"
+    );
+    let chunks: Vec<Result<Vec<u8>, RuntimeError>> =
+        vec![Ok(chunk.into_bytes()), Ok(b"data: [DONE]\n\n".to_vec())];
+    ForwardedChatCompletion {
+        status: 200,
+        content_type: Some("text/event-stream".to_string()),
+        body: futures::stream::iter(chunks).boxed(),
+    }
 }
 
 #[cfg(test)]
@@ -1439,6 +1521,46 @@ mod tests {
             .expect_err("invalid url");
 
         assert!(error.to_string().contains("invalid runtime url"));
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_injects_runtime_auth_token() {
+        let server = spawn_fixture(vec![http_response(200, "{}")]).await;
+        let target = ForwardTarget {
+            base_url: server.base_url.clone(),
+            auth_token: Some("s3cr3t-token".to_string()),
+        };
+        let body = serde_json::json!({ "model": "qwen9b", "messages": [] });
+
+        forward_chat_completion(&target, &body)
+            .await
+            .expect("forward");
+
+        let request = server.requests.lock().expect("requests")[0].to_lowercase();
+        assert!(
+            request.contains("authorization: bearer s3cr3t-token"),
+            "forwarded request must carry the runtime bearer token, got:\n{request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_chat_completion_omits_auth_when_unset() {
+        let server = spawn_fixture(vec![http_response(200, "{}")]).await;
+        let target = ForwardTarget {
+            base_url: server.base_url.clone(),
+            auth_token: None,
+        };
+        let body = serde_json::json!({ "model": "qwen9b", "messages": [] });
+
+        forward_chat_completion(&target, &body)
+            .await
+            .expect("forward");
+
+        let request = server.requests.lock().expect("requests")[0].to_lowercase();
+        assert!(
+            !request.contains("authorization:"),
+            "no auth header should be sent when the runtime has no token"
+        );
     }
 
     struct TestServer {

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -48,11 +48,11 @@ hardening when the local toolchain has the `clippy` component installed.
 | 25 eviction and pinning policy | Keep-hot workers are protected and eviction plans are explainable and gated. | `anemoi-policy`, `anemoi-core`, `anemoi-runtime` | Passing |
 | 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Passing |
 | 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Passing |
-| 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Pending |
+| 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Passing |
 
 ## Current Focus
 
-Build prompts 00-20 are passing. Prompts 21-27 are defined and pending. Prompt 28 is the active priority: inference forwarding gateway to make Anemoi an OpenAI-compatible endpoint for opencode.
+Build prompts 00-28 are passing. Prompt 28 (inference forwarding gateway) makes Anemoi an OpenAI-compatible endpoint for opencode: `POST /v1/chat/completions` treats the `model` field as a governance domain, runs `decide`, records telemetry, rewrites `model` to the selected runtime model, and streams the runtime response back with `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action` headers. Mock forwarding works without `ANEMOI_ENABLE_LIVE_EXECUTE=1`; non-mock forwarding requires it.
 
 Prompt 01 passed with:
 
@@ -263,3 +263,27 @@ asserts the recorded value round-trips, rather than asserting `is_ok`. The
 `resident_events` table follows the issue #12 schema with a NOT NULL
 `evidence_source`. `execution_events`/`policy_events` tables are deferred: no
 required test exercises them and they belong to later prompts (21-23).
+
+Prompt 28 passed with:
+
+- `inference_gateway_maps_model_field_to_domain`
+- `inference_gateway_strips_anemoi_prefix_from_model_field`
+- `inference_gateway_returns_error_for_unknown_domain`
+- `inference_gateway_runs_decide_before_forwarding`
+- `inference_gateway_rewrites_model_to_selected_model`
+- `inference_gateway_injects_runtime_auth_token` (`anemoi-runtime`)
+- `inference_gateway_records_decision_in_telemetry`
+- `inference_gateway_returns_decision_id_in_response_header`
+- `inference_gateway_requires_live_execute_flag_for_non_mock`
+- `inference_gateway_forwards_mock_without_live_execute_flag`
+- `inference_gateway_returns_structured_error_on_runtime_failure`
+
+The caller names a governance **domain** in the OpenAI `model` field (never a
+runtime model); the gateway resolves it (stripping an optional `anemoi-`
+prefix), runs the same decision path as `/decide` so telemetry is recorded,
+rewrites `model` to the selected runtime model, and streams the runtime
+response back. Forwarding lives in `anemoi-runtime` (`forward_chat_completion`
++ `mock_chat_completion`) so the daemon stays reqwest-free. Non-mock forwarding
+is gated behind `ANEMOI_ENABLE_LIVE_EXECUTE=1` (prompt 20); mock forwarding is
+always allowed for offline development. Runtime failures return an
+OpenAI-shaped structured error carrying the decision id.


### PR DESCRIPTION
## Summary
- Adds `POST /v1/chat/completions` and `GET /v1/models` to the daemon. The caller names a governance **domain** in the OpenAI `model` field (optional `anemoi-` prefix stripped); Anemoi runs the same decision path as `/decide` (recording telemetry), rewrites `model` to the selected runtime model, forwards, and streams the response back.
- Response carries `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action`. Errors are OpenAI-shaped and carry the decision id.
- Forwarding helpers (`forward_chat_completion`, `mock_chat_completion`, `ForwardTarget`, `ForwardedChatCompletion`) live in `anemoi-runtime` so the daemon stays reqwest-free. Non-mock forwarding is gated behind `ANEMOI_ENABLE_LIVE_EXECUTE=1`; mock forwarding is always allowed.

Closes #34. Folds #15.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test --workspace` (all 11 required gateway tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p anemoi-guard -- crates`

Required tests: `inference_gateway_maps_model_field_to_domain`, `inference_gateway_strips_anemoi_prefix_from_model_field`, `inference_gateway_returns_error_for_unknown_domain`, `inference_gateway_runs_decide_before_forwarding`, `inference_gateway_rewrites_model_to_selected_model`, `inference_gateway_injects_runtime_auth_token`, `inference_gateway_records_decision_in_telemetry`, `inference_gateway_returns_decision_id_in_response_header`, `inference_gateway_requires_live_execute_flag_for_non_mock`, `inference_gateway_forwards_mock_without_live_execute_flag`, `inference_gateway_returns_structured_error_on_runtime_failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)