### PR TITLE
feat(runtime): subscribe to llama-swap SSE events for residency (Closes #62)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -6,7 +6,7 @@ use anemoi_core::{
 use anemoi_policy::{EvictionCandidateResident, EvictionPlan, EvictionRequest, Scheduler};
 use anemoi_runtime::{
     DynRuntimeAdapter, ForwardedChatCompletion, LlamaCppAdapter, LlamaSwapAdapter,
-    MockRuntimeAdapter, OllamaAdapter,
+    LlamaSwapEventStream, MockRuntimeAdapter, OllamaAdapter,
 };
 use anemoi_telemetry::{DynDecisionLog, InMemoryDecisionLog};
 use axum::body::Body;
@@ -17,7 +17,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -278,6 +278,24 @@ impl StagingWorker {
         Ok(())
     }
 
+    /// Marks every `Pending` intent whose `background_model` is in `ready_models`
+    /// as `Completed`, returning the completed ids. This is the SSE-driven
+    /// completion path (issue #62): once the readiness stream reports a staged
+    /// model as ready, the intent is satisfied without calling the runtime.
+    pub async fn reconcile_ready(&self, ready_models: &HashSet<ModelId>) -> Vec<Uuid> {
+        let mut queue = self.queue.write().await;
+        let mut completed = Vec::new();
+        for intent in queue.iter_mut() {
+            if intent.state == StagingState::Pending
+                && ready_models.contains(&intent.background_model)
+            {
+                intent.mark_completed();
+                completed.push(intent.id);
+            }
+        }
+        completed
+    }
+
     pub async fn unblock_and_queue(
         &self,
         decision_id: Uuid,
@@ -397,6 +415,13 @@ pub struct AppState {
     decision_log: DynDecisionLog,
     reconciler: Reconciler,
     staging_worker: StagingWorker,
+    /// Live `/api/events` SSE subscribers for llama_swap runtimes. Held only to
+    /// keep the background tasks alive for the process lifetime — the tasks are
+    /// aborted when the last `AppState` clone drops. Shared via `Arc` so cloning
+    /// `AppState` (axum does this per request) does not abort them. Never read:
+    /// its sole purpose is ownership, so the SSE tasks live as long as the state.
+    #[allow(dead_code)]
+    event_streams: Arc<Vec<LlamaSwapEventStream>>,
     /// Test seam for the live-execute gate. `None` reads the real
     /// `ANEMOI_ENABLE_LIVE_EXECUTE` env var (production); `Some(_)` overrides it
     /// so tests can exercise the gate without mutating process-global state.
@@ -408,6 +433,7 @@ impl AppState {
         config.validate()?;
         let scheduler = Scheduler::new(config.clone());
         let mut runtimes = HashMap::new();
+        let mut event_streams = Vec::new();
 
         for (runtime_id, runtime) in &config.runtimes {
             let adapter: DynRuntimeAdapter = match runtime.adapter.as_str() {
@@ -440,6 +466,11 @@ impl AppState {
                     } else {
                         adapter
                     };
+                    // Subscribe to the push-based residency stream so inspect()
+                    // observes real load state. No-op outside a tokio runtime.
+                    if let Some(stream) = adapter.start_event_stream() {
+                        event_streams.push(stream);
+                    }
                     Arc::new(adapter)
                 }
                 "llama_cpp" | "llama_server" => {
@@ -472,6 +503,7 @@ impl AppState {
             decision_log,
             reconciler,
             staging_worker,
+            event_streams: Arc::new(event_streams),
             live_execute: None,
         })
     }
@@ -541,6 +573,7 @@ impl AppState {
             decision_log: Arc::new(InMemoryDecisionLog::default()),
             reconciler,
             staging_worker,
+            event_streams: Arc::new(Vec::new()),
             live_execute: None,
         })
     }
@@ -953,7 +986,33 @@ impl AppState {
         }
     }
 
+    /// Models the reconciliation cache currently reports as hot/serving — i.e.
+    /// ready to use. The residency comes from the push-updated `/api/events` SSE
+    /// cache by way of the last `inspect()` snapshots.
+    async fn ready_models(&self) -> HashSet<ModelId> {
+        self.reconciler
+            .get_snapshots()
+            .await
+            .into_iter()
+            .flat_map(|snapshot| snapshot.residents)
+            .filter(|resident| {
+                matches!(
+                    resident.state,
+                    ResidencyState::HotGpu | ResidencyState::Serving
+                )
+            })
+            .map(|resident| resident.model_id)
+            .collect()
+    }
+
     pub async fn run_staging_tick(&self) {
+        // A staged model the readiness stream already reports as ready needs no
+        // runtime call — complete those intents first (issue #62).
+        let ready_models = self.ready_models().await;
+        if !ready_models.is_empty() {
+            self.staging_worker.reconcile_ready(&ready_models).await;
+        }
+
         let pending = self.staging_worker.get_pending().await;
         for intent in pending {
             let runtime_id = intent.target_runtime.0.clone();
@@ -2144,6 +2203,109 @@ runtimes:
 
         let all = state.staging_worker.get_all().await;
         assert_eq!(all[0].state, StagingState::Completed);
+    }
+
+    #[tokio::test]
+    async fn reconcile_ready_completes_only_the_ready_models_intent() {
+        let worker = StagingWorker::new();
+
+        let mut ready_intent = StagingIntent::new(
+            Uuid::new_v4(),
+            None,
+            ModelId("granite8b".to_string()),
+            RuntimeId("swap_rt".to_string()),
+            "ready via SSE".to_string(),
+        );
+        ready_intent.mark_pending();
+        let ready_id = ready_intent.id;
+        worker.enqueue(ready_intent).await;
+
+        let mut loading_intent = StagingIntent::new(
+            Uuid::new_v4(),
+            None,
+            ModelId("minimax".to_string()),
+            RuntimeId("swap_rt".to_string()),
+            "still loading".to_string(),
+        );
+        loading_intent.mark_pending();
+        worker.enqueue(loading_intent).await;
+
+        let ready: HashSet<ModelId> = [ModelId("granite8b".to_string())].into_iter().collect();
+        let completed = worker.reconcile_ready(&ready).await;
+
+        assert_eq!(completed, vec![ready_id]);
+        let all = worker.get_all().await;
+        let granite = all
+            .iter()
+            .find(|i| i.background_model == ModelId("granite8b".to_string()))
+            .expect("granite intent");
+        assert_eq!(granite.state, StagingState::Completed);
+        let minimax = all
+            .iter()
+            .find(|i| i.background_model == ModelId("minimax".to_string()))
+            .expect("minimax intent");
+        assert_eq!(
+            minimax.state,
+            StagingState::Pending,
+            "a model not yet ready must remain pending"
+        );
+    }
+
+    #[tokio::test]
+    async fn staging_tick_completes_intent_from_readiness_without_live_execute() {
+        // Runtime typed non-mock so the runtime-load path is gated off, but
+        // backed by a mock adapter that reports the staged model hot — i.e. what
+        // the `/api/events` SSE cache produces via inspect().
+        let mut config = example_config();
+        let swap_rt = RuntimeId("swap_rt".to_string());
+        config.runtimes.insert(
+            swap_rt.clone(),
+            RuntimeConfig {
+                adapter: "llama_swap".to_string(),
+                base_url: Some("http://127.0.0.1:9".to_string()),
+                auth_token: None,
+                initial_residents: vec![],
+            },
+        );
+
+        let mut residents = HashMap::new();
+        residents.insert(
+            swap_rt.to_string(),
+            vec![ModelResident {
+                model_id: ModelId("granite8b".to_string()),
+                state: ResidencyState::HotGpu,
+                vram_mb: None,
+                ram_mb: None,
+                kv_cache_mb: None,
+                loaded_since: None,
+            }],
+        );
+        let state = AppState::with_mock_residents(config, residents)
+            .expect("state")
+            .with_live_execute(false);
+
+        state
+            .staging_worker
+            .unblock_and_queue(
+                Uuid::new_v4(),
+                None,
+                ModelId("granite8b".to_string()),
+                swap_rt,
+                "ready via SSE cache".to_string(),
+            )
+            .await;
+
+        // Populate the reconciler cache from inspect (mock reports granite8b hot).
+        state.run_reconciliation_tick().await;
+        state.run_staging_tick().await;
+
+        let all = state.staging_worker.get_all().await;
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].state,
+            StagingState::Completed,
+            "the readiness cache must complete the intent even with the live-load gate closed"
+        );
     }
 
     #[tokio::test]

--- a/crates/anemoi-runtime/Cargo.toml
+++ b/crates/anemoi-runtime/Cargo.toml
@@ -13,7 +13,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-uuid.workspace = true
-
-[dev-dependencies]
 tokio.workspace = true
+tracing.workspace = true
+uuid.workspace = true

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -8,7 +8,8 @@ use futures::stream::{BoxStream, StreamExt};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Url;
 use serde::Deserialize;
-use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use std::sync::{Arc, PoisonError, RwLock};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -408,6 +409,10 @@ pub struct LlamaSwapAdapter {
     base_url: Url,
     client: reqwest::Client,
     auth_token: Option<String>,
+    /// Push-updated model residency, maintained by [`LlamaSwapEventStream`]
+    /// from the `/api/events` SSE stream. Shared (cloned `Arc`) with any event
+    /// stream started off this adapter, so `inspect` observes live state.
+    model_states: ModelStateCache,
 }
 
 impl LlamaSwapAdapter {
@@ -425,12 +430,38 @@ impl LlamaSwapAdapter {
             base_url: Url::parse(base_url).map_err(|error| RuntimeError::Url(error.to_string()))?,
             client: reqwest::Client::builder().timeout(timeout).build()?,
             auth_token: None,
+            model_states: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
     pub fn with_bearer_token(mut self, token: impl Into<String>) -> Self {
         self.auth_token = Some(token.into());
         self
+    }
+
+    /// Read handle to the push-updated model-state cache. Empty until an event
+    /// stream is started via [`LlamaSwapAdapter::start_event_stream`] and the
+    /// first `modelStatus` frame arrives.
+    pub fn model_states(&self) -> ModelStateCache {
+        Arc::clone(&self.model_states)
+    }
+
+    /// Spawns the `/api/events` SSE subscriber on the current tokio runtime,
+    /// returning a handle that keeps the background task alive (the task is
+    /// aborted when the handle is dropped). Returns `None` when called outside a
+    /// tokio runtime (e.g. synchronous tests), leaving the cache empty rather
+    /// than panicking. The spawned task shares this adapter's cache, so
+    /// [`LlamaSwapAdapter::inspect`] reflects what the stream observes.
+    pub fn start_event_stream(&self) -> Option<LlamaSwapEventStream> {
+        let runtime = tokio::runtime::Handle::try_current().ok()?;
+        let events_url = self.base_url.join("/api/events").ok()?;
+        let cache = Arc::clone(&self.model_states);
+        let handle = runtime.spawn(run_event_stream(
+            events_url,
+            self.auth_token.clone(),
+            Arc::clone(&cache),
+        ));
+        Some(LlamaSwapEventStream { cache, handle })
     }
 
     pub async fn inspect_models(&self) -> Result<Vec<ModelId>, RuntimeError> {
@@ -476,6 +507,213 @@ struct LlamaSwapModel {
     id: String,
 }
 
+/// Process state of a model as reported over llama-swap's `/api/events` SSE
+/// stream. Mirrors the `state` field of each `modelStatus` entry; the lifecycle
+/// is `stopped` → `starting` → `ready` → `stopping` → `shutdown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlamaSwapModelState {
+    Stopped,
+    Starting,
+    Ready,
+    Stopping,
+    Shutdown,
+}
+
+impl LlamaSwapModelState {
+    fn from_wire(raw: &str) -> Option<Self> {
+        match raw {
+            "stopped" => Some(Self::Stopped),
+            "starting" => Some(Self::Starting),
+            "ready" => Some(Self::Ready),
+            "stopping" => Some(Self::Stopping),
+            "shutdown" => Some(Self::Shutdown),
+            _ => None,
+        }
+    }
+
+    /// Residency state to report for a model in this process state, or `None`
+    /// when the model is not loaded (stopped/shut down) and should be omitted
+    /// from a snapshot's resident list. `ready` is treated as hot on GPU;
+    /// `stopping` as draining.
+    pub fn residency(self) -> Option<ResidencyState> {
+        match self {
+            Self::Stopped | Self::Shutdown => None,
+            Self::Starting => Some(ResidencyState::Loading),
+            Self::Ready => Some(ResidencyState::HotGpu),
+            Self::Stopping => Some(ResidencyState::Draining),
+        }
+    }
+}
+
+/// Shared, push-updated map of model alias → llama-swap process state. Written
+/// by [`LlamaSwapEventStream`] on each SSE frame; read by
+/// [`LlamaSwapAdapter::inspect`].
+pub type ModelStateCache = Arc<RwLock<HashMap<String, LlamaSwapModelState>>>;
+
+#[derive(Debug, Deserialize)]
+struct ModelStatusFrame {
+    #[serde(rename = "type")]
+    kind: String,
+    /// llama-swap double-encodes the snapshot: `data` is a JSON *string*
+    /// containing the array of `{id, state}` entries, not a nested array.
+    data: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelStatusEntry {
+    id: String,
+    state: String,
+}
+
+/// Parses one SSE event's `data:` payload. Returns the model states carried by a
+/// `modelStatus` frame, or `None` for any other event type or malformed payload
+/// (heartbeats, comments, partial frames). Unknown `state` strings are dropped.
+fn parse_model_status_payload(payload: &str) -> Option<Vec<(String, LlamaSwapModelState)>> {
+    let frame: ModelStatusFrame = serde_json::from_str(payload).ok()?;
+    if frame.kind != "modelStatus" {
+        return None;
+    }
+    let entries: Vec<ModelStatusEntry> = serde_json::from_str(&frame.data).ok()?;
+    Some(
+        entries
+            .into_iter()
+            .filter_map(|entry| {
+                LlamaSwapModelState::from_wire(&entry.state).map(|state| (entry.id, state))
+            })
+            .collect(),
+    )
+}
+
+/// Incremental decoder for an SSE byte stream. Accumulates bytes across chunk
+/// boundaries, splits on blank-line event delimiters, and yields the parsed
+/// `modelStatus` updates from each complete event. Carriage returns are stripped
+/// so `\r\n\r\n` and `\n\n` delimiters are handled alike.
+#[derive(Default)]
+struct SseDecoder {
+    buffer: Vec<u8>,
+}
+
+impl SseDecoder {
+    fn push(&mut self, chunk: &[u8]) -> Vec<Vec<(String, LlamaSwapModelState)>> {
+        self.buffer
+            .extend(chunk.iter().copied().filter(|&b| b != b'\r'));
+        let mut updates = Vec::new();
+        while let Some(end) = find_subslice(&self.buffer, b"\n\n") {
+            let event: Vec<u8> = self.buffer.drain(..end + 2).collect();
+            if let Ok(text) = std::str::from_utf8(&event[..end]) {
+                if let Some(payload) = sse_data_field(text) {
+                    if let Some(update) = parse_model_status_payload(&payload) {
+                        updates.push(update);
+                    }
+                }
+            }
+        }
+        updates
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Joins the `data:` lines of one SSE event into a single payload, per the SSE
+/// spec (multiple `data:` lines concatenate with newlines). Returns `None` when
+/// the event has no data lines.
+fn sse_data_field(event: &str) -> Option<String> {
+    let mut data_lines = Vec::new();
+    for line in event.lines() {
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest));
+        }
+    }
+    (!data_lines.is_empty()).then(|| data_lines.join("\n"))
+}
+
+/// Replaces the cache with a full `modelStatus` snapshot. llama-swap pushes the
+/// complete model set on every change, so this is replace, not merge.
+fn apply_model_status(cache: &ModelStateCache, entries: Vec<(String, LlamaSwapModelState)>) {
+    let mut guard = cache.write().unwrap_or_else(PoisonError::into_inner);
+    *guard = entries.into_iter().collect();
+}
+
+/// Builds snapshot residents from a model-state cache, omitting models that are
+/// not loaded (stopped/shut down). Sorted by model id for deterministic output
+/// so reconciliation diffs are stable.
+fn residents_from_states(states: &HashMap<String, LlamaSwapModelState>) -> Vec<ModelResident> {
+    let mut residents: Vec<ModelResident> = states
+        .iter()
+        .filter_map(|(name, state)| {
+            state.residency().map(|residency| ModelResident {
+                model_id: normalize_model_id(name),
+                state: residency,
+                vram_mb: None,
+                ram_mb: None,
+                kv_cache_mb: None,
+                loaded_since: None,
+            })
+        })
+        .collect();
+    residents.sort_by(|a, b| a.model_id.0.cmp(&b.model_id.0));
+    residents
+}
+
+/// Background subscriber to llama-swap's `/api/events` SSE stream. Maintains a
+/// [`ModelStateCache`] without polling, reconnecting on disconnect. The spawned
+/// task is aborted when this handle is dropped.
+pub struct LlamaSwapEventStream {
+    cache: ModelStateCache,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl LlamaSwapEventStream {
+    /// Read handle to the cache this stream maintains.
+    pub fn cache(&self) -> ModelStateCache {
+        Arc::clone(&self.cache)
+    }
+}
+
+impl Drop for LlamaSwapEventStream {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+const EVENT_STREAM_RECONNECT_DELAY: Duration = Duration::from_secs(3);
+
+async fn run_event_stream(url: Url, auth_token: Option<String>, cache: ModelStateCache) {
+    let client = reqwest::Client::new();
+    loop {
+        if let Err(error) = stream_events_once(&client, &url, auth_token.as_deref(), &cache).await {
+            tracing::debug!(%url, %error, "llama-swap event stream disconnected; reconnecting");
+        }
+        tokio::time::sleep(EVENT_STREAM_RECONNECT_DELAY).await;
+    }
+}
+
+async fn stream_events_once(
+    client: &reqwest::Client,
+    url: &Url,
+    auth_token: Option<&str>,
+    cache: &ModelStateCache,
+) -> Result<(), RuntimeError> {
+    let mut request = client.get(url.clone());
+    if let Some(token) = auth_token {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?.error_for_status()?;
+    let mut stream = response.bytes_stream();
+    let mut decoder = SseDecoder::default();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        for update in decoder.push(&chunk) {
+            apply_model_status(cache, update);
+        }
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl RuntimeAdapter for LlamaSwapAdapter {
     fn id(&self) -> RuntimeId {
@@ -506,14 +744,22 @@ impl RuntimeAdapter for LlamaSwapAdapter {
         }
 
         let configured_models = self.inspect_models().await?;
+        let residents = {
+            let states = self
+                .model_states
+                .read()
+                .unwrap_or_else(PoisonError::into_inner);
+            residents_from_states(&states)
+        };
 
         Ok(RuntimeSnapshot {
             runtime_id: self.id.clone(),
             available: true,
-            // /v1/models proves configuration, not residency — see
-            // docs/live_validation/residency-truth-contract.md. residents stays
-            // empty until we have evidence the model is loaded.
-            residents: Vec::new(),
+            // Residents come from the push-updated `/api/events` SSE cache — the
+            // only residency evidence we trust. `/v1/models` proves
+            // configuration, not load state; see
+            // docs/live_validation/residency-truth-contract.md.
+            residents,
             configured_models,
             memory: RuntimeMemorySnapshot::default(),
             active_requests: Vec::new(),
@@ -1163,6 +1409,179 @@ mod tests {
             snapshot.residents.is_empty(),
             "configured models must not appear as residents"
         );
+    }
+
+    #[test]
+    fn llama_swap_model_state_maps_wire_strings() {
+        assert_eq!(
+            LlamaSwapModelState::from_wire("stopped"),
+            Some(LlamaSwapModelState::Stopped)
+        );
+        assert_eq!(
+            LlamaSwapModelState::from_wire("starting"),
+            Some(LlamaSwapModelState::Starting)
+        );
+        assert_eq!(
+            LlamaSwapModelState::from_wire("ready"),
+            Some(LlamaSwapModelState::Ready)
+        );
+        assert_eq!(
+            LlamaSwapModelState::from_wire("stopping"),
+            Some(LlamaSwapModelState::Stopping)
+        );
+        assert_eq!(
+            LlamaSwapModelState::from_wire("shutdown"),
+            Some(LlamaSwapModelState::Shutdown)
+        );
+        assert_eq!(LlamaSwapModelState::from_wire("bogus"), None);
+    }
+
+    #[test]
+    fn llama_swap_model_state_residency_omits_unloaded() {
+        assert_eq!(LlamaSwapModelState::Stopped.residency(), None);
+        assert_eq!(LlamaSwapModelState::Shutdown.residency(), None);
+        assert_eq!(
+            LlamaSwapModelState::Starting.residency(),
+            Some(ResidencyState::Loading)
+        );
+        assert_eq!(
+            LlamaSwapModelState::Ready.residency(),
+            Some(ResidencyState::HotGpu)
+        );
+        assert_eq!(
+            LlamaSwapModelState::Stopping.residency(),
+            Some(ResidencyState::Draining)
+        );
+    }
+
+    #[test]
+    fn parse_model_status_payload_extracts_double_encoded_states() {
+        // Captured shape: `data` is a JSON-encoded *string* of the entries.
+        let payload = r#"{"type":"modelStatus","data":"[{\"id\":\"minimax\",\"state\":\"starting\"},{\"id\":\"gemma\",\"state\":\"ready\"}]"}"#;
+
+        let parsed = parse_model_status_payload(payload).expect("modelStatus frame");
+
+        assert_eq!(
+            parsed,
+            vec![
+                ("minimax".to_string(), LlamaSwapModelState::Starting),
+                ("gemma".to_string(), LlamaSwapModelState::Ready),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_model_status_payload_ignores_other_frame_types() {
+        let payload = r#"{"type":"logData","data":"some log line"}"#;
+        assert_eq!(parse_model_status_payload(payload), None);
+    }
+
+    #[test]
+    fn sse_decoder_emits_frame_only_once_complete() {
+        let event = format!(
+            "data: {}\n\n",
+            r#"{"type":"modelStatus","data":"[{\"id\":\"gemma\",\"state\":\"ready\"}]"}"#
+        );
+        let (head, tail) = event.split_at(20);
+        let mut decoder = SseDecoder::default();
+
+        assert!(
+            decoder.push(head.as_bytes()).is_empty(),
+            "a partial frame must not emit an update"
+        );
+        let updates = decoder.push(tail.as_bytes());
+
+        assert_eq!(
+            updates,
+            vec![vec![("gemma".to_string(), LlamaSwapModelState::Ready)]]
+        );
+    }
+
+    #[test]
+    fn sse_decoder_splits_multiple_events_in_one_chunk() {
+        let chunk = format!(
+            "data: {}\n\ndata: {}\n\n",
+            r#"{"type":"modelStatus","data":"[{\"id\":\"a\",\"state\":\"starting\"}]"}"#,
+            r#"{"type":"modelStatus","data":"[{\"id\":\"a\",\"state\":\"ready\"}]"}"#
+        );
+        let mut decoder = SseDecoder::default();
+
+        let updates = decoder.push(chunk.as_bytes());
+
+        assert_eq!(
+            updates,
+            vec![
+                vec![("a".to_string(), LlamaSwapModelState::Starting)],
+                vec![("a".to_string(), LlamaSwapModelState::Ready)],
+            ]
+        );
+    }
+
+    #[test]
+    fn residents_from_states_omits_unloaded_and_sorts() {
+        let mut states = HashMap::new();
+        states.insert("models/qwen9b.gguf".to_string(), LlamaSwapModelState::Ready);
+        states.insert("granite8b".to_string(), LlamaSwapModelState::Starting);
+        states.insert("minimax".to_string(), LlamaSwapModelState::Stopped);
+
+        let residents = residents_from_states(&states);
+
+        assert_eq!(residents.len(), 2, "stopped model must be omitted");
+        assert_eq!(residents[0].model_id, ModelId("granite8b".to_string()));
+        assert_eq!(residents[0].state, ResidencyState::Loading);
+        assert_eq!(residents[1].model_id, ModelId("qwen9b".to_string()));
+        assert_eq!(residents[1].state, ResidencyState::HotGpu);
+    }
+
+    #[test]
+    fn apply_model_status_replaces_previous_snapshot() {
+        let cache: ModelStateCache = Arc::new(RwLock::new(HashMap::new()));
+        apply_model_status(
+            &cache,
+            vec![("gemma".to_string(), LlamaSwapModelState::Ready)],
+        );
+        apply_model_status(
+            &cache,
+            vec![("qwen9b".to_string(), LlamaSwapModelState::Starting)],
+        );
+
+        let guard = cache.read().expect("cache");
+        assert_eq!(guard.len(), 1, "full snapshot replaces, not merges");
+        assert_eq!(guard.get("qwen9b"), Some(&LlamaSwapModelState::Starting));
+        assert!(guard.get("gemma").is_none());
+    }
+
+    #[tokio::test]
+    async fn llama_swap_inspect_reports_residents_from_event_cache() {
+        let server = spawn_fixture(vec![
+            http_response(200, "{}"),
+            http_response(200, r#"{"data":[{"id":"models/qwen9b.gguf"}]}"#),
+        ])
+        .await;
+        let adapter = LlamaSwapAdapter::new(RuntimeId("llama_swap".to_string()), &server.base_url)
+            .expect("adapter");
+
+        // Simulate the SSE stream having observed a ready and a stopped model.
+        apply_model_status(
+            &adapter.model_states(),
+            vec![
+                ("qwen9b".to_string(), LlamaSwapModelState::Ready),
+                ("granite8b".to_string(), LlamaSwapModelState::Stopped),
+            ],
+        );
+
+        let snapshot = adapter.inspect().await.expect("snapshot");
+
+        assert_eq!(
+            snapshot.residents.len(),
+            1,
+            "only the ready model is resident"
+        );
+        assert_eq!(
+            snapshot.residents[0].model_id,
+            ModelId("qwen9b".to_string())
+        );
+        assert_eq!(snapshot.residents[0].state, ResidencyState::HotGpu);
     }
 
     #[tokio::test]

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -49,10 +49,11 @@ hardening when the local toolchain has the `clippy` component installed.
 | 26 operator status surface | Status and CLI output show runtime health, residents, staging, policy, and unknown/stale state. | `anemoi-daemon`, `anemoi-cli` | Passing |
 | 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Passing |
 | 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Passing |
+| 29 llama-swap residency events | Live `/api/events` SSE stream feeds observed model state into `inspect()` residents and drives staging completion without polling or false residency. | `anemoi-runtime`, `anemoi-daemon` | Passing |
 
 ## Current Focus
 
-Build prompts 00-28 are passing. Prompt 28 (inference forwarding gateway) makes Anemoi an OpenAI-compatible endpoint for opencode: `POST /v1/chat/completions` treats the `model` field as a governance domain, runs `decide`, records telemetry, rewrites `model` to the selected runtime model, and streams the runtime response back with `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action` headers. Mock forwarding works without `ANEMOI_ENABLE_LIVE_EXECUTE=1`; non-mock forwarding requires it.
+Build prompts 00-29 are passing. Prompt 29 (issue #62) subscribes to llama-swap's `/api/events` SSE stream so `inspect()` reports residents from observed model state and staging intents complete on real readiness. Prompt 28 (inference forwarding gateway) makes Anemoi an OpenAI-compatible endpoint for opencode: `POST /v1/chat/completions` treats the `model` field as a governance domain, runs `decide`, records telemetry, rewrites `model` to the selected runtime model, and streams the runtime response back with `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action` headers. Mock forwarding works without `ANEMOI_ENABLE_LIVE_EXECUTE=1`; non-mock forwarding requires it.
 
 Prompt 01 passed with:
 
@@ -287,3 +288,35 @@ response back. Forwarding lives in `anemoi-runtime` (`forward_chat_completion`
 is gated behind `ANEMOI_ENABLE_LIVE_EXECUTE=1` (prompt 20); mock forwarding is
 always allowed for offline development. Runtime failures return an
 OpenAI-shaped structured error carrying the decision id.
+
+Prompt 29 (issue #62) passed with:
+
+- `llama_swap_model_state_maps_wire_strings`
+- `llama_swap_model_state_residency_omits_unloaded`
+- `parse_model_status_payload_extracts_double_encoded_states`
+- `parse_model_status_payload_ignores_other_frame_types`
+- `sse_decoder_emits_frame_only_once_complete`
+- `sse_decoder_splits_multiple_events_in_one_chunk`
+- `residents_from_states_omits_unloaded_and_sorts`
+- `apply_model_status_replaces_previous_snapshot`
+- `llama_swap_inspect_reports_residents_from_event_cache`
+- `reconcile_ready_completes_only_the_ready_models_intent` (`anemoi-daemon`)
+- `staging_tick_completes_intent_from_readiness_without_live_execute` (`anemoi-daemon`)
+
+llama-swap pushes a full `modelStatus` snapshot on `GET /api/events` whenever a
+process changes state. The frame's `data` field is a **double-encoded** JSON
+string (parse the outer object, then parse `data` as the entry array). The
+adapter subscribes once, decodes the SSE byte stream incrementally
+(`SseDecoder` splits on blank lines and tolerates frames spanning chunks), and
+**replaces** its `ModelStateCache` on every snapshot so the cache mirrors
+llama-swap exactly. `inspect()` derives residents from that observed cache
+only — never from `/v1/models` (which lists *available*, not *resident*,
+models), preserving the prompt 18 residency-truth contract: with no event seen,
+residents stay empty. Wire states map `starting → Loading`, `ready → HotGpu`,
+`stopping → Draining`; `stopped`/`shutdown` produce no resident. The stream
+runs on its own untimed `reqwest` client (the adapter's inspect client keeps
+its 5s timeout) and reconnects after a 3s delay on disconnect. The daemon holds
+the subscribers in an `Arc<Vec<LlamaSwapEventStream>>` whose final drop aborts
+the tasks. `StagingWorker::reconcile_ready` then completes a pending staging
+intent the moment its background model is observed `HotGpu`/`Serving`, so
+staging closes from real readiness rather than a mock execute.


### PR DESCRIPTION
## Summary
- Subscribe once to llama-swap's `GET /api/events` SSE stream and decode the double-encoded `modelStatus` snapshots into a shared `ModelStateCache`, so `inspect()` reports residents from **observed** state instead of returning empty — without polling and without claiming residency from `/v1/models` (which only lists *available* models).
- Daemon starts one subscriber per `llama_swap` runtime, held in an `Arc<Vec<LlamaSwapEventStream>>` whose final drop aborts the tasks; the stream uses its own untimed `reqwest` client and reconnects after a delay on disconnect.
- `StagingWorker::reconcile_ready` completes a pending intent the moment its background model is observed `HotGpu`/`Serving`, closing staging from real readiness rather than a mock execute.

Wire states map `starting → Loading`, `ready → HotGpu`, `stopping → Draining`; `stopped`/`shutdown` produce no resident. With no event observed, residents stay empty (prompt 18 residency-truth contract preserved).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test --workspace` (anemoi-runtime 54, anemoi-daemon 60; 11 new tests for prompt 29)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p anemoi-guard -- crates` (12 files scanned, no violations)
- [x] **Live-validated** against real llama-swap on prometheus: subscribed the real adapter to `/api/events`, triggered a model load, and observed `inspect().residents` transition empty → `qwen3.5-2b-mtp=HotGpu` → `gemma-4-e2b-it=Loading` → `gemma-4-e2b-it=HotGpu`, confirming real double-encoded frame decode, full-snapshot replace semantics, and the cold→loading→hot_gpu lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)