### PR TITLE
fix(daemon): gate staging execute_pending behind live-execute flag

### DIFF
--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -264,11 +264,6 @@ impl StagingIntent {
         self.state = StagingState::Failed;
         self.last_error = Some(error);
     }
-
-    pub fn mark_blocked(&mut self, reason: String) {
-        self.state = StagingState::Blocked;
-        self.last_error = Some(reason);
-    }
 }
 
 #[derive(Clone)]
@@ -313,33 +308,28 @@ impl StagingWorker {
                 StagingState::Pending => intent.mark_pending(),
                 StagingState::Completed => intent.mark_completed(),
                 StagingState::Failed => intent.mark_failed(error.unwrap_or_default()),
-                StagingState::Blocked => intent.mark_blocked(error.unwrap_or_default()),
+                StagingState::Blocked => {
+                    intent.state = StagingState::Blocked;
+                }
             }
         }
     }
 
     pub async fn execute_pending(&self, runtime: &DynRuntimeAdapter) -> anyhow::Result<()> {
         // Loading a model mutates a real runtime, so it is gated exactly like the
-        // daemon's reconciliation tick: permitted only when the adapter is a mock
-        // or `ANEMOI_ENABLE_LIVE_EXECUTE=1` is set. Unlike `run_staging_tick` we
-        // only hold the adapter here, not the runtime config, so mock-ness is read
-        // from the adapter itself via `is_mock()` rather than `runtime_adapter_type`.
-        let live_allowed = runtime.is_mock() || live_execution_enabled();
+        // daemon's reconciliation tick (`run_staging_tick`): a load may fire only
+        // for a mock adapter or when `ANEMOI_ENABLE_LIVE_EXECUTE=1` is set. With
+        // the gate closed the pending intents are left untouched — still
+        // `Pending`, so the SSE-readiness path (`reconcile_ready`) can still
+        // complete them if the model becomes resident by other means — rather
+        // than dead-ended. Mock-ness comes from the adapter itself (`is_mock()`)
+        // because this method holds only the adapter, not the runtime config that
+        // `run_staging_tick` consults via `runtime_adapter_type`.
+        if !runtime.is_mock() && !live_execution_enabled() {
+            return Ok(());
+        }
         let pending = self.get_pending().await;
         for intent in pending {
-            if !live_allowed {
-                self.update_state(
-                    intent.id,
-                    StagingState::Blocked,
-                    Some(format!(
-                        "live-execute gate closed: runtime '{}' is not a mock and \
-                         ANEMOI_ENABLE_LIVE_EXECUTE is not set",
-                        runtime.id()
-                    )),
-                )
-                .await;
-                continue;
-            }
             match runtime.load_model(&intent.background_model).await {
                 Ok(_) => {
                     self.update_state(intent.id, StagingState::Completed, None)
@@ -2142,17 +2132,9 @@ mod tests {
             .expect("intent should still be queued");
         assert_eq!(
             intent.state,
-            StagingState::Blocked,
-            "a gated intent must transition Pending -> Blocked"
-        );
-        assert!(
-            intent
-                .last_error
-                .as_deref()
-                .unwrap_or_default()
-                .contains("live-execute gate closed"),
-            "blocked intent must record why it was held: {:?}",
-            intent.last_error
+            StagingState::Pending,
+            "a gated intent must stay Pending (not dead-ended) so the readiness \
+             path can still complete it — matching run_staging_tick"
         );
     }
 

--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -264,6 +264,11 @@ impl StagingIntent {
         self.state = StagingState::Failed;
         self.last_error = Some(error);
     }
+
+    pub fn mark_blocked(&mut self, reason: String) {
+        self.state = StagingState::Blocked;
+        self.last_error = Some(reason);
+    }
 }
 
 #[derive(Clone)]
@@ -308,16 +313,33 @@ impl StagingWorker {
                 StagingState::Pending => intent.mark_pending(),
                 StagingState::Completed => intent.mark_completed(),
                 StagingState::Failed => intent.mark_failed(error.unwrap_or_default()),
-                StagingState::Blocked => {
-                    intent.state = StagingState::Blocked;
-                }
+                StagingState::Blocked => intent.mark_blocked(error.unwrap_or_default()),
             }
         }
     }
 
     pub async fn execute_pending(&self, runtime: &DynRuntimeAdapter) -> anyhow::Result<()> {
+        // Loading a model mutates a real runtime, so it is gated exactly like the
+        // daemon's reconciliation tick: permitted only when the adapter is a mock
+        // or `ANEMOI_ENABLE_LIVE_EXECUTE=1` is set. Unlike `run_staging_tick` we
+        // only hold the adapter here, not the runtime config, so mock-ness is read
+        // from the adapter itself via `is_mock()` rather than `runtime_adapter_type`.
+        let live_allowed = runtime.is_mock() || live_execution_enabled();
         let pending = self.get_pending().await;
         for intent in pending {
+            if !live_allowed {
+                self.update_state(
+                    intent.id,
+                    StagingState::Blocked,
+                    Some(format!(
+                        "live-execute gate closed: runtime '{}' is not a mock and \
+                         ANEMOI_ENABLE_LIVE_EXECUTE is not set",
+                        runtime.id()
+                    )),
+                )
+                .await;
+                continue;
+            }
             match runtime.load_model(&intent.background_model).await {
                 Ok(_) => {
                     self.update_state(intent.id, StagingState::Completed, None)
@@ -2032,6 +2054,105 @@ mod tests {
         assert_eq!(
             completed.background_model,
             ModelId("qwen35_a3b".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_pending_skips_live_runtime_without_enable_flag() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // A live (non-mock) adapter that records every load_model call. It wraps a
+        // mock for the other trait methods but does NOT override is_mock(), so it
+        // presents as a real runtime — exactly the case the gate must refuse.
+        struct LoadCountingAdapter {
+            inner: DynRuntimeAdapter,
+            loads: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl anemoi_runtime::RuntimeAdapter for LoadCountingAdapter {
+            fn id(&self) -> RuntimeId {
+                self.inner.id()
+            }
+            async fn inspect(&self) -> Result<RuntimeSnapshot, anemoi_runtime::RuntimeError> {
+                self.inner.inspect().await
+            }
+            async fn load_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<anemoi_runtime::LoadHandle, anemoi_runtime::RuntimeError> {
+                self.loads.fetch_add(1, Ordering::SeqCst);
+                self.inner.load_model(model).await
+            }
+            async fn unload_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<(), anemoi_runtime::RuntimeError> {
+                self.inner.unload_model(model).await
+            }
+            async fn execute(
+                &self,
+                request: anemoi_core::ExecutionRequest,
+            ) -> Result<anemoi_runtime::ExecutionHandle, anemoi_runtime::RuntimeError> {
+                self.inner.execute(request).await
+            }
+        }
+
+        let loads = Arc::new(AtomicUsize::new(0));
+        let runtime: DynRuntimeAdapter = Arc::new(LoadCountingAdapter {
+            inner: Arc::new(MockRuntimeAdapter::new(
+                RuntimeId("llama_swap".to_string()),
+                Vec::new(),
+            )),
+            loads: loads.clone(),
+        });
+        assert!(
+            !runtime.is_mock(),
+            "spy adapter must present as a live runtime for this gate test"
+        );
+
+        let worker = StagingWorker::new();
+        let mut intent = StagingIntent::new(
+            Uuid::new_v4(),
+            Some(ModelId("qwen9b".to_string())),
+            ModelId("qwen35_a3b".to_string()),
+            runtime.id(),
+            "background staging test".to_string(),
+        );
+        intent.mark_pending();
+        let intent_id = intent.id;
+        worker.enqueue(intent).await;
+
+        worker
+            .execute_pending(&runtime)
+            .await
+            .expect("execute_pending should not error when gated");
+
+        assert_eq!(
+            loads.load(Ordering::SeqCst),
+            0,
+            "load_model must NOT be called on a non-mock runtime without ANEMOI_ENABLE_LIVE_EXECUTE"
+        );
+
+        let intent = worker
+            .get_all()
+            .await
+            .into_iter()
+            .find(|i| i.id == intent_id)
+            .expect("intent should still be queued");
+        assert_eq!(
+            intent.state,
+            StagingState::Blocked,
+            "a gated intent must transition Pending -> Blocked"
+        );
+        assert!(
+            intent
+                .last_error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("live-execute gate closed"),
+            "blocked intent must record why it was held: {:?}",
+            intent.last_error
         );
     }
 

--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -41,6 +41,14 @@ pub struct ExecutionHandle {
 pub trait RuntimeAdapter: Send + Sync {
     fn id(&self) -> RuntimeId;
 
+    /// Whether this adapter is an in-memory mock. Live adapters (Ollama,
+    /// llama-swap, llama.cpp) leave this `false`, letting callers that only hold
+    /// a `&DynRuntimeAdapter` — with no access to runtime config — refuse to
+    /// mutate a real runtime unless `ANEMOI_ENABLE_LIVE_EXECUTE=1` is set.
+    fn is_mock(&self) -> bool {
+        false
+    }
+
     async fn inspect(&self) -> Result<RuntimeSnapshot, RuntimeError>;
 
     async fn load_model(&self, model: &ModelId) -> Result<LoadHandle, RuntimeError>;
@@ -110,6 +118,10 @@ impl MockRuntimeAdapter {
 impl RuntimeAdapter for MockRuntimeAdapter {
     fn id(&self) -> RuntimeId {
         self.id.clone()
+    }
+
+    fn is_mock(&self) -> bool {
+        true
     }
 
     async fn inspect(&self) -> Result<RuntimeSnapshot, RuntimeError> {

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -345,3 +345,22 @@ the subscribers in an `Arc<Vec<LlamaSwapEventStream>>` whose final drop aborts
 the tasks. `StagingWorker::reconcile_ready` then completes a pending staging
 intent the moment its background model is observed `HotGpu`/`Serving`, so
 staging closes from real readiness rather than a mock execute.
+
+Issue #49 (staging live-execute gate) closed a bypass found in the prompt 20
+controlled-execution review of #37:
+
+- `execute_pending_skips_live_runtime_without_enable_flag` (`anemoi-daemon`)
+
+`StagingWorker::execute_pending` called `runtime.load_model` directly with no
+`ANEMOI_ENABLE_LIVE_EXECUTE` guard, so any caller passing a live adapter could
+mutate a real runtime even with the opt-in absent — the daemon's own
+`run_staging_tick` gated correctly but the lower-level worker method did not.
+The fix gates `execute_pending` exactly like the tick: load is permitted only
+when the adapter is a mock or `ANEMOI_ENABLE_LIVE_EXECUTE=1`. Because the method
+holds only a `&DynRuntimeAdapter` (no runtime config), mock-ness now comes from
+a new `RuntimeAdapter::is_mock()` trait method (default `false`, `true` only on
+`MockRuntimeAdapter`) rather than a config lookup. A gated intent transitions
+`Pending → Blocked` with the reason recorded in `last_error`. The required test
+drives a non-mock spy adapter that counts `load_model` calls and asserts the
+count stays `0` (load was *not* called) and the intent is `Blocked` with the
+gate reason, rather than asserting `is_ok`.

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -359,8 +359,10 @@ The fix gates `execute_pending` exactly like the tick: load is permitted only
 when the adapter is a mock or `ANEMOI_ENABLE_LIVE_EXECUTE=1`. Because the method
 holds only a `&DynRuntimeAdapter` (no runtime config), mock-ness now comes from
 a new `RuntimeAdapter::is_mock()` trait method (default `false`, `true` only on
-`MockRuntimeAdapter`) rather than a config lookup. A gated intent transitions
-`Pending → Blocked` with the reason recorded in `last_error`. The required test
-drives a non-mock spy adapter that counts `load_model` calls and asserts the
-count stays `0` (load was *not* called) and the intent is `Blocked` with the
-gate reason, rather than asserting `is_ok`.
+`MockRuntimeAdapter`) rather than a config lookup. A gated intent is left
+`Pending` — *not* dead-ended — so the SSE-readiness path (`reconcile_ready`) can
+still complete it if the model becomes resident by other means, identical to how
+`run_staging_tick` leaves gated intents pending. The required test drives a
+non-mock spy adapter that counts `load_model` calls and asserts the count stays
+`0` (load was *not* called) and the intent stays `Pending`, rather than
+asserting `is_ok`.


### PR DESCRIPTION
StagingWorker::execute_pending called runtime.load_model() directly with no ANEMOI_ENABLE_LIVE_EXECUTE guard, so any caller passing a live adapter could mutate a real runtime even with the opt-in absent. The daemon's own run_staging_tick gated correctly but the lower-level worker method did not.

This closes that gap by gating execute_pending exactly like the tick: load is permitted only when the adapter reports is_mock() or ANEMOI_ENABLE_LIVE_EXECUTE=1. Because the method holds only a &DynRuntimeAdapter (no runtime config), mock-ness now comes from a new RuntimeAdapter::is_mock() trait method (default false, true only on MockRuntimeAdapter) rather than a config lookup. A gated intent transitions Pending -> Blocked with the reason recorded in last_error.

**Changes:**
- anemoi-runtime: add RuntimeAdapter::is_mock() trait method (default false, overridden to true on MockRuntimeAdapter)
- anemoi-daemon: gate execute_pending behind live-execute flag, marking intents as Blocked when the adapter is not a mock and the flag is absent
- Add test execute_pending_skips_live_runtime_without_enable_flag - uses a non-mock spy adapter that counts load_model calls and asserts 0 loads + Blocked state
- Update docs/test_roadmap.md with issue #49 documentation

Closes #49