### PR TITLE
Carry gateway selection signals into policy

### DIFF
--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -1,7 +1,7 @@
 use anemoi_core::{
-    ActionKind, ActionPlan, AnemoiConfig, Decision, DecisionAction, DomainId, ExecutionMode,
-    InferenceRequest, ModelId, ModelResident, RequestId, ResidencyState, RuntimeId,
-    RuntimeSnapshot,
+    ActionKind, ActionPlan, AnemoiConfig, Decision, DecisionAction, DomainId, EscalationIntent,
+    ExecutionMode, InferenceRequest, ModelId, ModelResident, QualityFloor, RequestId,
+    ResidencyState, RuntimeId, RuntimeSnapshot,
 };
 use anemoi_policy::{EvictionCandidateResident, EvictionPlan, EvictionRequest, Scheduler};
 use anemoi_runtime::{
@@ -2995,6 +2995,161 @@ runtimes:
         })
     }
 
+    fn large_context_gateway_state() -> AppState {
+        let yaml = r#"
+domains:
+  coding:
+    rosters:
+      - small
+      - large
+residency_groups:
+  small:
+    purpose: [interactive]
+    keep_hot: true
+    allow_background_load: true
+    models: [tiny8b]
+  large:
+    purpose: [large context]
+    keep_hot: false
+    allow_background_load: true
+    models: [wide32b]
+models:
+  tiny8b:
+    family: tiny
+    parameter_class: 8b
+    context_window: 8192
+    cold_load_estimate_ms: 0
+    supports_streaming: true
+    supported_runtimes: [mock]
+  wide32b:
+    family: wide
+    parameter_class: 32b
+    context_window: 65536
+    cold_load_estimate_ms: 45000
+    supports_streaming: true
+    supported_runtimes: [mock]
+runtimes:
+  mock:
+    adapter: mock
+    initial_residents:
+      - model_id: tiny8b
+        state: hot_gpu
+continuity:
+  keep_small_worker_hot: true
+  background_load: true
+  max_blank_wait_ms: 1500
+  prefer_degraded_response_over_silence: true
+"#;
+        let config = AnemoiConfig::from_yaml_str(yaml).expect("large context config");
+        AppState::new(config, Arc::new(InMemoryDecisionLog::default())).expect("state")
+    }
+
+    #[test]
+    fn inference_gateway_derives_prompt_tokens_estimate_from_messages() {
+        let body = serde_json::json!({
+            "model": "coding",
+            "messages": [{ "role": "user", "content": "hello world" }]
+        });
+
+        let request = gateway_inference_request("coding", &body).expect("request");
+
+        assert_eq!(request.prompt_tokens_estimate, Some(10));
+    }
+
+    #[test]
+    fn inference_gateway_uses_max_tokens_as_output_estimate() {
+        let mut body = chat_body("coding");
+        body["max_tokens"] = serde_json::json!(123);
+
+        let request = gateway_inference_request("coding", &body).expect("request");
+
+        assert_eq!(request.max_output_tokens, Some(123));
+    }
+
+    #[test]
+    fn inference_gateway_accepts_anemoi_selection_metadata() {
+        let body = serde_json::json!({
+            "model": "coding",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "max_tokens": 12,
+            "anemoi": {
+                "prompt_tokens_estimate": 42000,
+                "max_output_tokens": 2048,
+                "latency_budget_ms": 9000,
+                "quality_floor": { "minimum_parameter_class": "32b" },
+                "escalation_intent": {
+                    "task_type": "planning",
+                    "context": "prior small-model context"
+                }
+            }
+        });
+
+        let request = gateway_inference_request("coding", &body).expect("request");
+
+        assert_eq!(request.prompt_tokens_estimate, Some(42000));
+        assert_eq!(request.max_output_tokens, Some(2048));
+        assert_eq!(request.latency_budget_ms, Some(9000));
+        assert_eq!(
+            request
+                .quality_floor
+                .as_ref()
+                .and_then(|floor| floor.minimum_parameter_class.as_deref()),
+            Some("32b")
+        );
+        assert_eq!(
+            request
+                .escalation_intent
+                .as_ref()
+                .and_then(|intent| intent.context.as_deref()),
+            Some("prior small-model context")
+        );
+    }
+
+    #[tokio::test]
+    async fn inference_gateway_large_context_request_selects_larger_context_model() {
+        let body = serde_json::json!({
+            "model": "coding",
+            "messages": [{ "role": "user", "content": "large context request" }],
+            "anemoi": {
+                "prompt_tokens_estimate": 20000,
+                "max_output_tokens": 1000
+            }
+        });
+
+        let response = router(large_context_gateway_state())
+            .oneshot(json_request("/v1/chat/completions", &body))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("x-anemoi-selected-model")
+                .expect("selected model")
+                .to_str()
+                .expect("ascii"),
+            "wide32b"
+        );
+    }
+
+    #[test]
+    fn inference_gateway_strips_anemoi_metadata_before_forwarding() {
+        let body = serde_json::json!({
+            "model": "coding",
+            "messages": [{ "role": "user", "content": "hello" }],
+            "anemoi": { "prompt_tokens_estimate": 42000 }
+        });
+
+        let forwarded = gateway_forward_body(body, &ModelId("wide32b".to_string()));
+
+        assert_eq!(forwarded["model"], "wide32b");
+        assert!(
+            forwarded.get("anemoi").is_none(),
+            "private Anemoi metadata must not be forwarded to runtimes"
+        );
+    }
+
     async fn body_value(response: Response) -> Value {
         let bytes = to_bytes(response.into_body(), usize::MAX)
             .await
@@ -4024,6 +4179,127 @@ fn gateway_error(
     response
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct GatewaySelectionMetadata {
+    prompt_tokens_estimate: Option<u32>,
+    max_output_tokens: Option<u32>,
+    latency_budget_ms: Option<u64>,
+    quality_floor: Option<QualityFloor>,
+    escalation_intent: Option<EscalationIntent>,
+}
+
+fn gateway_selection_metadata(
+    body: &serde_json::Value,
+) -> Result<GatewaySelectionMetadata, String> {
+    body.get("anemoi")
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .map(|metadata| metadata.unwrap_or_default())
+        .map_err(|error| format!("invalid `anemoi` selection metadata: {error}"))
+}
+
+fn gateway_inference_request(
+    domain: &str,
+    body: &serde_json::Value,
+) -> Result<InferenceRequest, String> {
+    let metadata = gateway_selection_metadata(body)?;
+    Ok(InferenceRequest {
+        id: RequestId::new(),
+        domain: DomainId(domain.to_string()),
+        mode: ExecutionMode::Interactive,
+        prompt_tokens_estimate: metadata
+            .prompt_tokens_estimate
+            .or_else(|| estimate_prompt_tokens_from_messages(body)),
+        max_output_tokens: metadata
+            .max_output_tokens
+            .or_else(|| numeric_body_field_u32(body, "max_tokens"))
+            .or_else(|| numeric_body_field_u32(body, "max_completion_tokens")),
+        latency_budget_ms: metadata
+            .latency_budget_ms
+            .or(Some(DEFAULT_GATEWAY_LATENCY_BUDGET_MS)),
+        quality_floor: metadata.quality_floor,
+        escalation_intent: metadata.escalation_intent,
+    })
+}
+
+fn numeric_body_field_u32(body: &serde_json::Value, field: &str) -> Option<u32> {
+    body.get(field)
+        .and_then(|value| value.as_u64())
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn estimate_prompt_tokens_from_messages(body: &serde_json::Value) -> Option<u32> {
+    let messages = body.get("messages")?.as_array()?;
+    let mut total = 2u32;
+    for message in messages {
+        total = total.saturating_add(4);
+        total = total.saturating_add(
+            message
+                .get("role")
+                .and_then(|role| role.as_str())
+                .map(estimate_text_tokens)
+                .unwrap_or(0),
+        );
+        total = total.saturating_add(
+            message
+                .get("name")
+                .and_then(|name| name.as_str())
+                .map(estimate_text_tokens)
+                .unwrap_or(0),
+        );
+        total = total.saturating_add(estimate_message_content_tokens(message.get("content")));
+    }
+    Some(total)
+}
+
+fn estimate_message_content_tokens(content: Option<&serde_json::Value>) -> u32 {
+    match content {
+        Some(serde_json::Value::String(text)) => estimate_text_tokens(text),
+        Some(serde_json::Value::Array(parts)) => parts
+            .iter()
+            .map(|part| match part {
+                serde_json::Value::String(text) => estimate_text_tokens(text),
+                serde_json::Value::Object(object) => object
+                    .get("text")
+                    .and_then(|text| text.as_str())
+                    .map(estimate_text_tokens)
+                    .unwrap_or(0),
+                _ => 0,
+            })
+            .sum(),
+        Some(serde_json::Value::Object(object)) => object
+            .get("text")
+            .and_then(|text| text.as_str())
+            .map(estimate_text_tokens)
+            .unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn estimate_text_tokens(text: &str) -> u32 {
+    let chars = u32::try_from(text.chars().count()).unwrap_or(u32::MAX);
+    if chars == 0 {
+        0
+    } else {
+        chars.saturating_add(3) / 4
+    }
+}
+
+fn gateway_forward_body(
+    mut body: serde_json::Value,
+    selected_model: &ModelId,
+) -> serde_json::Value {
+    if let Some(object) = body.as_object_mut() {
+        object.remove("anemoi");
+        object.insert(
+            "model".to_string(),
+            serde_json::Value::String(selected_model.to_string()),
+        );
+    }
+    body
+}
+
 /// `POST /v1/chat/completions` — OpenAI-compatible inference forwarding. The
 /// caller names a domain in `model`; Anemoi decides which runtime model serves
 /// it, records the decision, rewrites `model` to the selected model, forwards
@@ -4031,7 +4307,7 @@ fn gateway_error(
 /// runtime model directly.
 async fn chat_completions(
     State(state): State<AppState>,
-    Json(mut body): Json<serde_json::Value>,
+    Json(body): Json<serde_json::Value>,
 ) -> Response {
     let Some(model_field) = body
         .get("model")
@@ -4056,15 +4332,9 @@ async fn chat_completions(
     }
 
     // Run the same decision path as POST /decide; this records telemetry.
-    let request = InferenceRequest {
-        id: RequestId::new(),
-        domain: DomainId(domain.clone()),
-        mode: ExecutionMode::Interactive,
-        prompt_tokens_estimate: None,
-        max_output_tokens: None,
-        latency_budget_ms: Some(DEFAULT_GATEWAY_LATENCY_BUDGET_MS),
-        quality_floor: None,
-        escalation_intent: None,
+    let request = match gateway_inference_request(&domain, &body) {
+        Ok(request) => request,
+        Err(error) => return gateway_error(StatusCode::BAD_REQUEST, error, None),
     };
     let decision = match state.decide(&request).await {
         Ok(decision) => decision,
@@ -4097,8 +4367,9 @@ async fn chat_completions(
         );
     }
 
-    // The caller's domain hint is replaced with the governed model id.
-    body["model"] = serde_json::Value::String(selected_model.to_string());
+    // The caller's domain hint is replaced with the governed model id. Private
+    // Anemoi metadata is consumed locally and never forwarded to runtimes.
+    let body = gateway_forward_body(body, &selected_model);
 
     let forwarded = if is_mock {
         anemoi_runtime::mock_chat_completion(&selected_model.to_string())

--- a/crates/anemoi-policy/src/lib.rs
+++ b/crates/anemoi-policy/src/lib.rs
@@ -153,9 +153,18 @@ impl Scheduler {
             let candidates = snapshot
                 .configured_models
                 .iter()
-                .map(|model_id| {
+                .filter_map(|model_id| {
                     let profile = synthesize_profile(model_id, live_runtime_id);
-                    generate_candidate(&live_group, &profile, live_runtime_id, snapshot)
+                    if context_window_rejection(request, &profile).is_some() {
+                        None
+                    } else {
+                        Some(generate_candidate(
+                            &live_group,
+                            &profile,
+                            live_runtime_id,
+                            snapshot,
+                        ))
+                    }
                 })
                 .collect();
 
@@ -203,6 +212,15 @@ impl Scheduler {
                     });
                     continue;
                 };
+
+                if let Some(reason) = context_window_rejection(request, model) {
+                    rejected_options.push(RejectedOption {
+                        model_id: Some(model_id.clone()),
+                        runtime_id: None,
+                        reason,
+                    });
+                    continue;
+                }
 
                 let runtime_candidates = model
                     .supported_runtimes
@@ -454,6 +472,19 @@ fn score_candidate(
         );
     }
 
+    if let Some((required, available)) = context_window_fit(request, model) {
+        push(
+            &mut score,
+            &mut reasons,
+            "context_window.fit",
+            10,
+            format!(
+                "request requires {required} token(s) and {} provides a {available} token context window",
+                model.id
+            ),
+        );
+    }
+
     let pressure = PressureModel::default().assess(&PressureInputs {
         memory: &candidate.runtime_memory,
         vram_required_mb: model.vram_required_mb,
@@ -532,6 +563,29 @@ fn quality_score(model: &ModelProfile) -> i32 {
         .parse::<i32>()
         .unwrap_or(1);
     digits.clamp(1, 100)
+}
+
+fn request_required_tokens(request: &InferenceRequest) -> Option<u32> {
+    request
+        .prompt_tokens_estimate
+        .map(|prompt| prompt.saturating_add(request.max_output_tokens.unwrap_or(0)))
+}
+
+fn context_window_fit(request: &InferenceRequest, model: &ModelProfile) -> Option<(u32, u32)> {
+    let required = request_required_tokens(request)?;
+    let available = model.context_window?;
+    (required <= available).then_some((required, available))
+}
+
+fn context_window_rejection(request: &InferenceRequest, model: &ModelProfile) -> Option<String> {
+    let required = request_required_tokens(request)?;
+    let available = model.context_window?;
+    (required > available).then(|| {
+        format!(
+            "request requires {required} token(s) but {} context window is {available} token(s)",
+            model.id
+        )
+    })
 }
 
 fn deny_decision(request: &InferenceRequest, rejected_options: Vec<RejectedOption>) -> Decision {
@@ -1375,6 +1429,71 @@ runtimes:
 "#,
         )
         .expect("candidate config")
+    }
+
+    #[test]
+    fn context_window_fit_rejects_candidate_too_small_for_request() {
+        let scheduler = Scheduler::new(candidate_config());
+        let mut request = candidate_request();
+        request.prompt_tokens_estimate = Some(9000);
+        request.max_output_tokens = Some(1);
+
+        let generated = scheduler
+            .generate_candidates(&request, &[candidate_snapshot(true)])
+            .expect("candidates");
+
+        assert!(
+            generated
+                .candidates
+                .iter()
+                .all(|candidate| candidate.model_id != ModelId("granite8b".to_string())),
+            "granite8b must be rejected because its 8192-token context is too small"
+        );
+        assert!(
+            generated.rejected_options.iter().any(|rejected| {
+                rejected.model_id == Some(ModelId("granite8b".to_string()))
+                    && rejected.reason.contains("requires 9001")
+                    && rejected.reason.contains("8192")
+            }),
+            "rejected options should explain the required and available context window"
+        );
+    }
+
+    #[test]
+    fn context_window_fit_allows_unknown_request_size() {
+        let scheduler = Scheduler::new(candidate_config());
+        let mut request = candidate_request();
+        request.prompt_tokens_estimate = None;
+        request.max_output_tokens = Some(500);
+
+        let generated = scheduler
+            .generate_candidates(&request, &[candidate_snapshot(true)])
+            .expect("candidates");
+
+        assert!(
+            generated
+                .candidates
+                .iter()
+                .any(|candidate| candidate.model_id == ModelId("granite8b".to_string())),
+            "unknown prompt size must not create a false context-window rejection"
+        );
+    }
+
+    #[test]
+    fn context_window_explanation_names_required_and_available_tokens() {
+        let scheduler = Scheduler::new(candidate_config());
+        let decision = scheduler
+            .decide(&candidate_request(), &[candidate_snapshot(true)])
+            .expect("decision");
+
+        assert!(
+            decision.explanation.reasons.iter().any(|reason| {
+                reason.code == "context_window.fit"
+                    && reason.detail.contains("1500 token")
+                    && reason.detail.contains("32768 token context window")
+            }),
+            "selected-model explanation should name required and available context tokens"
+        );
     }
 
     // ── live roster tests ──────────────────────────────────────────────────

--- a/docs/build_prompts/30-gateway-selection-signals.md
+++ b/docs/build_prompts/30-gateway-selection-signals.md
@@ -1,0 +1,62 @@
+# Prompt 30: Gateway Selection Signals
+
+## Goal
+
+Make OpenAI-compatible gateway requests carry explicit, reviewable selection
+signals into policy so repeated requests do not collapse to the same model when
+their prompt shape differs.
+
+## Issue
+
+Closes #77.
+
+## Scope
+
+Allowed:
+
+- derive conservative prompt token estimates from `messages`
+- carry standard output-token limits into `InferenceRequest`
+- accept explicit Anemoi metadata under an extension object
+- strip the extension before forwarding to runtimes
+- enforce context-window fit when request size and model capacity are known
+
+Not allowed:
+
+- infer task type from prompt content
+- introduce prompt planning or agent memory
+- change runtime execution internals
+
+## Required Tests
+
+Add failing tests first:
+
+- `context_window_fit_rejects_candidate_too_small_for_request`
+- `context_window_fit_allows_unknown_request_size`
+- `context_window_explanation_names_required_and_available_tokens`
+- `inference_gateway_derives_prompt_tokens_estimate_from_messages`
+- `inference_gateway_uses_max_tokens_as_output_estimate`
+- `inference_gateway_accepts_anemoi_selection_metadata`
+- `inference_gateway_large_context_request_selects_larger_context_model`
+- `inference_gateway_strips_anemoi_metadata_before_forwarding`
+
+## Acceptance Criteria
+
+- `/v1/chat/completions` builds `InferenceRequest` with prompt/output token
+  estimates when the request supplies enough information.
+- The gateway accepts explicit metadata in `anemoi` without forwarding that
+  private extension to runtimes.
+- Policy rejects candidates whose known context window is too small for the
+  known request size.
+- Selected-model explanations include a context-window reason when both request
+  size and selected model context are known.
+- A large-context gateway request can select a larger suitable model instead of
+  the hot small model.
+
+## Validation
+
+```powershell
+cargo fmt --check
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo run -p anemoi-guard -- crates
+```

--- a/docs/test_roadmap.md
+++ b/docs/test_roadmap.md
@@ -1,15 +1,16 @@
 # Anemoi Test Roadmap
 
-**Current Status**: ✅ **28/28 Prompts Complete and Passing**
+**Current Status**: **30/30 Prompts Complete and Passing**
 
 This roadmap keeps the Rust rewrite prompt-aligned. Later scaffolding can exist,
 but a prompt is not accepted until its tests prove the contract named here.
 
-## Summary (2026-05-30)
+## Summary (2026-06-01)
 
 All core features are complete and production-ready:
-- **Prompts 00-28**: All passing with required tests
+- **Prompts 00-30**: All passing with required tests
 - **Issues #30-34**: All merged to main with full integration
+- **Issue #77**: Gateway request shape now reaches policy as selection signals
 - **Integration**: Pi and OpenCode configured and tested
 - **Gateway**: OpenAI-compatible inference endpoint live
 - **Telemetry**: SQLite event store recording all decisions
@@ -68,10 +69,22 @@ hardening when the local toolchain has the `clippy` component installed.
 | 27 durable event store | Optional SQLite history records decisions, snapshots, staging, action plans, and explanations. | `anemoi-telemetry`, `anemoi-daemon` | Passing |
 | 28 inference forwarding gateway | `POST /v1/chat/completions` maps model field to domain, runs decide, forwards to selected runtime, streams response. | `anemoi-daemon`, `anemoi-runtime`, `anemoi-core` | Passing |
 | 29 llama-swap residency events | Live `/api/events` SSE stream feeds observed model state into `inspect()` residents and drives staging completion without polling or false residency. | `anemoi-runtime`, `anemoi-daemon` | Passing |
+| 30 gateway selection signals | Gateway chat requests carry prompt/output estimates and explicit Anemoi metadata into policy, and policy enforces known context-window fit. | `anemoi-daemon`, `anemoi-policy` | Passing |
 
 ## Current Focus
 
-Build prompts 00-29 are passing. Prompt 29 (issue #62) subscribes to llama-swap's `/api/events` SSE stream so `inspect()` reports residents from observed model state and staging intents complete on real readiness. Prompt 28 (inference forwarding gateway) makes Anemoi an OpenAI-compatible endpoint for opencode: `POST /v1/chat/completions` treats the `model` field as a governance domain, runs `decide`, records telemetry, rewrites `model` to the selected runtime model, and streams the runtime response back with `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action` headers. Mock forwarding works without `ANEMOI_ENABLE_LIVE_EXECUTE=1`; non-mock forwarding requires it.
+Build prompts 00-30 are passing. Prompt 30 (issue #77) makes gateway request shape a real policy input: `POST /v1/chat/completions` estimates prompt tokens from `messages`, carries `max_tokens`/`max_completion_tokens` as output estimates, accepts private `anemoi` selection metadata, strips that metadata before forwarding, and rejects known-too-small context-window candidates. Prompt 29 (issue #62) subscribes to llama-swap's `/api/events` SSE stream so `inspect()` reports residents from observed model state and staging intents complete on real readiness. Prompt 28 (inference forwarding gateway) makes Anemoi an OpenAI-compatible endpoint for opencode: `POST /v1/chat/completions` treats the `model` field as a governance domain, runs `decide`, records telemetry, rewrites `model` to the selected runtime model, and streams the runtime response back with `X-Anemoi-Decision-Id`, `X-Anemoi-Selected-Model`, and `X-Anemoi-Action` headers. Mock forwarding works without `ANEMOI_ENABLE_LIVE_EXECUTE=1`; non-mock forwarding requires it.
+
+Prompt 30 passed with:
+
+- `context_window_fit_rejects_candidate_too_small_for_request`
+- `context_window_fit_allows_unknown_request_size`
+- `context_window_explanation_names_required_and_available_tokens`
+- `inference_gateway_derives_prompt_tokens_estimate_from_messages`
+- `inference_gateway_uses_max_tokens_as_output_estimate`
+- `inference_gateway_accepts_anemoi_selection_metadata`
+- `inference_gateway_large_context_request_selects_larger_context_model`
+- `inference_gateway_strips_anemoi_metadata_before_forwarding`
 
 Issue #12 (resident transition emission) is complete: the reconciliation loop now diffs resident sets each tick and records every state change to the `resident_events` table through the `DecisionLog` trait, with a non-anonymous evidence source naming the adapter and reconciliation round. The event store stays optional (default no-op trait method; only SQLite persists transitions).
 


### PR DESCRIPTION
## Summary

- Map OpenAI gateway request shape into `InferenceRequest`: prompt token estimates from `messages`, output estimates from `max_tokens`/`max_completion_tokens`, and explicit private `anemoi` metadata.
- Strip private `anemoi` metadata before forwarding to runtimes.
- Enforce known context-window fit in policy, with explanations and rejected options when a candidate is too small.
- Add prompt 30 and promote the roadmap to Passing for issue #77.

Closes #77

## Validation

- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run -p anemoi-guard -- crates`
- `git diff --check`
- `rg -n ^(<<<<<<<|=======|>>>>>>>) --glob !target/**`