### PR TITLE
fix(policy): rank unknown-idle residents last in eviction (#85)

### DIFF
--- a/crates/anemoi-policy/src/eviction.rs
+++ b/crates/anemoi-policy/src/eviction.rs
@@ -8,6 +8,7 @@
 //! controlled execution path to act on.
 
 use anemoi_core::{DecisionReason, ModelId, ResidencyState, RuntimeId};
+use std::cmp::Ordering;
 
 /// A resident under consideration for eviction, with the policy-relevant flags
 /// already resolved from config and runtime state.
@@ -137,12 +138,20 @@ pub fn plan_evictions(request: &EvictionRequest<'_>) -> EvictionPlan {
 
     // Prefer the most idle candidate first; unknown idle ranks last. Ties break
     // on model id for determinism.
+    //
+    // Known idle always ranks ahead of unknown idle, and among known residents a
+    // higher `idle_secs` (a better eviction candidate) comes first. A previous
+    // `unwrap_or(0)` key tied `None` with `Some(0)`, which let the alphabetical
+    // model-id tiebreak surface an unknown-idle resident ahead of a known
+    // zero-idle one — contradicting "unknown idle ranks last".
     plan.candidates.sort_by(|a, b| {
-        let a_key = a.idle_secs.unwrap_or(0);
-        let b_key = b.idle_secs.unwrap_or(0);
-        b_key
-            .cmp(&a_key)
-            .then_with(|| a.model_id.to_string().cmp(&b.model_id.to_string()))
+        match (a.idle_secs, b.idle_secs) {
+            (Some(x), Some(y)) => y.cmp(&x),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        }
+        .then_with(|| a.model_id.to_string().cmp(&b.model_id.to_string()))
     });
 
     plan

--- a/crates/anemoi-policy/tests/eviction.rs
+++ b/crates/anemoi-policy/tests/eviction.rs
@@ -1,0 +1,65 @@
+//! Eviction ranking behavior (issue #85): unknown idle time must rank last.
+
+use anemoi_core::{ModelId, ResidencyState, RuntimeId};
+use anemoi_policy::{plan_evictions, EvictionCandidateResident, EvictionPlan, EvictionRequest};
+
+fn resident(model: &str, idle_secs: Option<u64>) -> EvictionCandidateResident {
+    EvictionCandidateResident {
+        model_id: ModelId(model.to_string()),
+        runtime_id: RuntimeId("rt".to_string()),
+        state: ResidencyState::HotGpu,
+        keep_hot: false,
+        pinned: false,
+        idle_secs,
+    }
+}
+
+fn candidate_order(plan: &EvictionPlan) -> Vec<String> {
+    plan.candidates
+        .iter()
+        .map(|c| c.model_id.to_string())
+        .collect()
+}
+
+#[test]
+fn eviction_unknown_idle_ranks_last() {
+    // "aardvark" has unknown idle and sorts alphabetically before "zebra",
+    // which has a known idle of 0. Despite the alphabetical edge, the unknown
+    // resident must rank last (it is the worst eviction candidate, not the best).
+    let residents = [resident("aardvark", None), resident("zebra", Some(0))];
+    let plan = plan_evictions(&EvictionRequest {
+        residents: &residents,
+        force: false,
+    });
+
+    assert_eq!(
+        candidate_order(&plan),
+        vec!["zebra".to_string(), "aardvark".to_string()]
+    );
+}
+
+#[test]
+fn eviction_orders_known_idle_descending_then_unknown() {
+    // Most-idle known resident first, then descending by idle time, with all
+    // unknown-idle residents last (ordered among themselves by model id).
+    let residents = [
+        resident("alpha", None),
+        resident("bravo", Some(5)),
+        resident("charlie", Some(120)),
+        resident("delta", None),
+    ];
+    let plan = plan_evictions(&EvictionRequest {
+        residents: &residents,
+        force: false,
+    });
+
+    assert_eq!(
+        candidate_order(&plan),
+        vec![
+            "charlie".to_string(), // 120s idle, best candidate
+            "bravo".to_string(),   // 5s idle
+            "alpha".to_string(),   // unknown idle, model-id tiebreak
+            "delta".to_string(),   // unknown idle
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

`plan_evictions` sorted candidates with `idle_secs.unwrap_or(0)`, tying `None` with `Some(0)`. The alphabetical model-id tiebreak could then surface an unknown-idle resident *ahead* of a known zero-idle one — contradicting the documented rule "unknown idle ranks last" (an unknown-idle resident is the *worst* eviction candidate, not the best).

## Fix

Sort known idle ahead of unknown, descending by `idle_secs` among known residents, with the model-id tiebreak preserved for determinism. (The issue's suggested `unwrap_or(u64::MAX)` one-liner would have pushed unknown idle to *first* in the descending sort — the opposite of the intended behavior — so this uses an explicit ordering instead.)

## Testing

New `crates/anemoi-policy/tests/eviction.rs`:
- `eviction_unknown_idle_ranks_last` — the issue's repro (`[aardvark:None, zebra:Some(0)]` → `[zebra, aardvark]`).
- `eviction_orders_known_idle_descending_then_unknown` — pins the full ordering.

`cargo fmt --check`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo run -p anemoi-guard -- crates` all pass.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)