### PR TITLE
fix(policy): make active-request penalty grow with load (#80)

### DIFF
--- a/crates/anemoi-policy/src/pressure.rs
+++ b/crates/anemoi-policy/src/pressure.rs
@@ -79,10 +79,10 @@ pub struct PressureModel {
     pub high_penalty: i32,
     /// Penalty applied to a cold-load candidate under elevated pressure.
     pub elevated_penalty: i32,
-    /// Penalty applied per active request on the target runtime.
+    /// Penalty applied per active request on the target runtime. The cumulative
+    /// active-request penalty is linear in the request count (`each * count`) so
+    /// a busier runtime always scores lower than a less busy one.
     pub active_request_penalty_each: i32,
-    /// Floor for the cumulative active-request penalty.
-    pub active_request_penalty_floor: i32,
 }
 
 impl Default for PressureModel {
@@ -93,7 +93,6 @@ impl Default for PressureModel {
             high_penalty: -25,
             elevated_penalty: -10,
             active_request_penalty_each: -5,
-            active_request_penalty_floor: -20,
         }
     }
 }
@@ -186,11 +185,10 @@ impl PressureModel {
     }
 
     fn active_request_reason(&self, count: usize, reasons: &mut Vec<PressureReason>) -> i32 {
-        let impact = if count == 0 {
-            0
-        } else {
-            (self.active_request_penalty_each * count as i32).max(self.active_request_penalty_floor)
-        };
+        // Linear in the request count: a runtime serving more requests is always
+        // penalized more. A previous `.max(floor)` capped this at the floor, so
+        // counts beyond the floor/each boundary all scored identically.
+        let impact = self.active_request_penalty_each * count as i32;
         reasons.push(PressureReason {
             code: "pressure.active_requests".to_string(),
             detail: format!("runtime is serving {count} active request(s)"),

--- a/crates/anemoi-policy/tests/pressure.rs
+++ b/crates/anemoi-policy/tests/pressure.rs
@@ -1,0 +1,43 @@
+//! Active-request pressure behavior (issue #80): the penalty must keep growing
+//! with load instead of saturating at a floor.
+
+use anemoi_core::RuntimeMemorySnapshot;
+use anemoi_policy::{PressureInputs, PressureModel};
+
+fn active_request_penalty(count: usize) -> i32 {
+    // Empty memory snapshot => VRAM/RAM pressure is Unknown (no memory penalty),
+    // so the resulting penalty is purely the active-request contribution.
+    let memory = RuntimeMemorySnapshot::default();
+    PressureModel::default()
+        .assess(&PressureInputs {
+            memory: &memory,
+            vram_required_mb: None,
+            ram_required_mb: None,
+            is_cold_load: false,
+            active_request_count: count,
+        })
+        .penalty
+}
+
+#[test]
+fn active_request_penalty_grows_with_count_beyond_floor() {
+    // Previously `(each * count).max(floor)` capped the penalty at -20, so 5, 50,
+    // and 100 active requests all scored identically. The penalty is now linear
+    // in the request count (each = -5) and keeps growing past the old floor.
+    let p5 = active_request_penalty(5);
+    let p50 = active_request_penalty(50);
+    let p100 = active_request_penalty(100);
+
+    assert_eq!(p5, -25);
+    assert_eq!(p50, -250);
+    assert_eq!(p100, -500);
+
+    assert!(
+        p50 < p5,
+        "50 requests ({p50}) must be penalized more than 5 ({p5})"
+    );
+    assert!(
+        p100 < p50,
+        "100 requests ({p100}) must be penalized more than 50 ({p50})"
+    );
+}


### PR DESCRIPTION
## Summary

`PressureModel::active_request_reason` computed `(each * count).max(floor)`, capping the active-request penalty at the floor (`-20`). Once `each * count` passed the floor, a runtime with 5, 50, or 100 active requests all scored identically — the request count stopped influencing scheduling.

## Fix

Make the penalty linear in the request count (`each * count`) so a busier runtime is always penalized more, and remove the now-misleading `active_request_penalty_floor` field. `PressureModel` is only ever constructed via `Default`, so this field was never config-bound (no `config/*.yaml` change needed).

## Testing

New `crates/anemoi-policy/tests/pressure.rs`:
- `active_request_penalty_grows_with_count_beyond_floor` — asserts exact penalties `-25 / -250 / -500` for counts `5 / 50 / 100` and that each higher count penalizes more.

Existing `active_request_pressure_penalizes_busy_runtime` (count=4 → -20) is unchanged. `cargo fmt --check`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `anemoi-guard` all pass.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)