### PR TITLE
fix(runtime): OllamaAdapter::load_model returns Unsupported, not a fake handle (#92)

### DIFF
--- a/crates/anemoi-runtime/src/lib.rs
+++ b/crates/anemoi-runtime/src/lib.rs
@@ -255,11 +255,15 @@ impl RuntimeAdapter for OllamaAdapter {
         })
     }
 
-    async fn load_model(&self, model: &ModelId) -> Result<LoadHandle, RuntimeError> {
-        Ok(LoadHandle {
-            id: Uuid::new_v4(),
-            model_id: model.clone(),
-        })
+    /// Ollama loads a model into memory lazily on its first inference request,
+    /// and weight downloads happen via an explicit `ollama pull` outside Anemoi's
+    /// control plane. Anemoi decides residency; it does not mutate runtime
+    /// infrastructure (AGENTS.md §2/§4), so it does not proactively load Ollama
+    /// models. Returning `Unsupported` (rather than a fabricated `LoadHandle`)
+    /// keeps staging honest: the worker observes that the load did not happen
+    /// instead of marking the intent `Completed` for a load that never ran.
+    async fn load_model(&self, _model: &ModelId) -> Result<LoadHandle, RuntimeError> {
+        Err(RuntimeError::Unsupported("ollama load"))
     }
 
     async fn unload_model(&self, _model: &ModelId) -> Result<(), RuntimeError> {
@@ -1863,6 +1867,25 @@ mod tests {
 
         assert_eq!(snapshot.residents.len(), 1);
         assert_eq!(snapshot.residents[0].state, ResidencyState::HotGpu);
+    }
+
+    #[tokio::test]
+    async fn ollama_load_model_is_unsupported() {
+        // Ollama loads lazily on first inference; Anemoi does not proactively
+        // load it. load_model must report Unsupported (not a fake LoadHandle) so
+        // staging does not mark an intent Completed for a load that never ran.
+        let adapter = OllamaAdapter::new(RuntimeId("ollama".to_string()), "http://localhost:11434")
+            .expect("adapter");
+
+        let error = adapter
+            .load_model(&ModelId("qwen9b".to_string()))
+            .await
+            .expect_err("ollama load must be unsupported");
+
+        assert_eq!(
+            error.to_string(),
+            "runtime operation is not supported: ollama load"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`OllamaAdapter::load_model` returned `Ok(LoadHandle { .. })` **without any HTTP call**. The staging worker then marked the intent `Completed`, so operators saw a successful load when no model was ever requested from Ollama — and inference routed to that "loaded" model would fail.

## Fix

Return `Err(RuntimeError::Unsupported("ollama load"))`, matching `LlamaCppAdapter::load_model` and the existing `OllamaAdapter::unload_model`. Ollama loads lazily on first inference, and weight pulls happen via `ollama pull` outside Anemoi's control plane. Anemoi decides residency; it does not mutate runtime infrastructure (AGENTS.md §2/§4). A doc comment explains the rationale and why a fabricated handle is wrong (it makes staging dishonest).

## Testing

- `ollama_load_model_is_unsupported` — asserts the `runtime operation is not supported: ollama load` error.

No existing test relied on the fake handle — daemon staging tests use `MockRuntimeAdapter` (whose `load_model` still returns `Ok`), and no runtime test called Ollama's `load_model`.

`cargo fmt --check`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `anemoi-guard` all pass.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)