### PR TITLE
fix(daemon): refresh stale/errored reconciliation cache before deciding (#51)

### DIFF
--- a/crates/anemoi-daemon/src/lib.rs
+++ b/crates/anemoi-daemon/src/lib.rs
@@ -142,6 +142,27 @@ impl Reconciler {
     pub async fn has_cache(&self) -> bool {
         !self.cache.read().await.is_empty()
     }
+
+    /// True when a decision should re-inspect before relying on the cache: the
+    /// cache is empty, or any entry has aged past the TTL, is flagged stale, or
+    /// carries a recorded inspect error. This is what stops `decide` from
+    /// scheduling indefinitely on evidence that has expired or come from a
+    /// since-failed runtime.
+    pub async fn needs_refresh(&self) -> bool {
+        let cache = self.cache.read().await;
+        if cache.is_empty() {
+            return true;
+        }
+        let now = Utc::now();
+        cache.values().any(|r| {
+            r.is_stale
+                || r.last_error.is_some()
+                || now
+                    .signed_duration_since(r.last_inspected)
+                    .num_milliseconds()
+                    > self.ttl_ms as i64
+        })
+    }
 }
 
 impl Default for Reconciler {
@@ -985,7 +1006,12 @@ impl AppState {
     }
 
     pub async fn decide(&self, request: &InferenceRequest) -> anyhow::Result<Decision> {
-        if !self.reconciler.has_cache().await {
+        // Refresh before scheduling when the cache is empty or any entry is stale
+        // (TTL exceeded) or carries an inspect error, so decisions never run on
+        // evidence that has aged out or come from a since-failed runtime. When
+        // every entry is fresh this is a no-op, preserving cache reuse across a
+        // burst of decisions.
+        if self.reconciler.needs_refresh().await {
             self.run_reconciliation_tick().await;
         }
         let snapshots = self.reconciler.get_snapshots().await;
@@ -1975,6 +2001,49 @@ mod tests {
         assert!(
             !snapshot.snapshot.available,
             "snapshot should be marked unavailable"
+        );
+    }
+
+    #[tokio::test]
+    async fn needs_refresh_is_false_for_fresh_and_true_after_ttl_expiry() {
+        let reconciler = Reconciler::new(10);
+        reconciler
+            .update(
+                "rt",
+                RuntimeSnapshot {
+                    runtime_id: RuntimeId("rt".to_string()),
+                    available: true,
+                    residents: vec![],
+                    configured_models: vec![],
+                    memory: anemoi_core::RuntimeMemorySnapshot::default(),
+                    active_requests: vec![],
+                },
+            )
+            .await;
+
+        assert!(
+            !reconciler.needs_refresh().await,
+            "a freshly updated entry needs no refresh"
+        );
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        assert!(
+            reconciler.needs_refresh().await,
+            "an entry aged past the TTL must trigger a refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn needs_refresh_is_true_when_an_entry_has_an_inspect_error() {
+        let reconciler = Reconciler::new(60_000);
+        reconciler
+            .record_error("rt", "connection refused".to_string())
+            .await;
+
+        assert!(
+            reconciler.needs_refresh().await,
+            "a cached snapshot with last_error must not be served as-is; it triggers a refresh"
         );
     }
 
@@ -2985,6 +3054,80 @@ runtimes:
         assert_eq!(
             total, 1,
             "decide burst must reuse the reconciler cache; got {total} inspects"
+        );
+    }
+
+    #[tokio::test]
+    async fn decide_reinspects_when_cache_is_stale() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingAdapter {
+            inner: DynRuntimeAdapter,
+            inspects: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl anemoi_runtime::RuntimeAdapter for CountingAdapter {
+            fn id(&self) -> RuntimeId {
+                self.inner.id()
+            }
+            async fn inspect(&self) -> Result<RuntimeSnapshot, anemoi_runtime::RuntimeError> {
+                self.inspects.fetch_add(1, Ordering::SeqCst);
+                self.inner.inspect().await
+            }
+            async fn load_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<anemoi_runtime::LoadHandle, anemoi_runtime::RuntimeError> {
+                self.inner.load_model(model).await
+            }
+            async fn unload_model(
+                &self,
+                model: &ModelId,
+            ) -> Result<(), anemoi_runtime::RuntimeError> {
+                self.inner.unload_model(model).await
+            }
+            async fn execute(
+                &self,
+                request: anemoi_core::ExecutionRequest,
+            ) -> Result<anemoi_runtime::ExecutionHandle, anemoi_runtime::RuntimeError> {
+                self.inner.execute(request).await
+            }
+        }
+
+        let mut state = AppState::new(example_config(), Arc::new(InMemoryDecisionLog::default()))
+            .expect("state");
+        let inspects = Arc::new(AtomicUsize::new(0));
+        let original = state
+            .runtimes
+            .get("mock")
+            .expect("mock runtime present")
+            .clone();
+        state.runtimes.insert(
+            "mock".to_string(),
+            Arc::new(CountingAdapter {
+                inner: original,
+                inspects: inspects.clone(),
+            }),
+        );
+
+        // First decision populates the cache (one inspect); a second reuses it.
+        state.decide(&sample_request()).await.expect("decision");
+        state.decide(&sample_request()).await.expect("decision");
+        assert_eq!(
+            inspects.load(Ordering::SeqCst),
+            1,
+            "a fresh cache must be reused without re-inspecting"
+        );
+
+        // Mark the cache stale (as TTL expiry would). The next decision must
+        // re-inspect instead of scheduling on the aged snapshot.
+        state.reconciler().mark_stale().await;
+        state.decide(&sample_request()).await.expect("decision");
+        assert_eq!(
+            inspects.load(Ordering::SeqCst),
+            2,
+            "a stale cache must trigger re-inspection before deciding"
         );
     }
 


### PR DESCRIPTION
## Summary

`AppState::decide` ran an initial reconciliation tick only when the cache was *empty*, then always read `get_snapshots()` (which drops `is_stale`/`last_error`). Once the cache had any entry, decisions were served from it **indefinitely** — scheduling on residency/availability evidence that had aged past the TTL or come from a runtime that had since failed inspection.

## Fix

Add `Reconciler::needs_refresh()` — true when the cache is empty, any entry is stale (TTL exceeded or flagged), or any carries an inspect error — and gate `decide()`'s reconciliation tick on it. Fresh caches are still reused (no re-inspection), so the decide-burst fast path is preserved; stale or errored entries are re-inspected before scheduling. `decide` is reachable from the `/decide` route, so the fix applies to the real binary.

## Testing

- `needs_refresh_is_false_for_fresh_and_true_after_ttl_expiry` — TTL=10ms, fresh ⇒ false; after 50ms ⇒ true (mirrors the acceptance case).
- `needs_refresh_is_true_when_an_entry_has_an_inspect_error` — `last_error` ⇒ refresh (not served as-is).
- `decide_reinspects_when_cache_is_stale` — through `decide()`: a fresh cache is reused (1 inspect across 2 decides), then `mark_stale()` forces re-inspection on the next decide.

Existing `decide_burst_reads_reconciler_cache_not_runtime_inspect` and `decide_uses_reconciled_snapshot_without_reinspecting_when_fresh` still pass. `cargo fmt --check`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `anemoi-guard` all pass.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)