### PR TITLE
Ignore daemon run capture files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -483,5 +483,6 @@ $RECYCLE.BIN/
 *.swp
 
 # Local daemon run captures (stdout/stderr redirects, not for commit)
-/daemon_output.txt
-/daemon_error.txt
+/daemon_*.txt
+/*_output.txt
+/*_error.txt


### PR DESCRIPTION
﻿Closes #123

## Summary
- Broaden the local daemon capture ignore block to cover root-level daemon capture files and generic stdout/stderr run captures.

## Validation
- `git check-ignore -v daemon_output.txt daemon_error.txt daemon_test.txt smoke_output.txt smoke_error.txt`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" --glob "!target/**"`
